### PR TITLE
Implemented: code to clear the shipments after changing store and logout(#20d7jmt)

### DIFF
--- a/changelogs/unreleased/-20d7jmt.yml
+++ b/changelogs/unreleased/-20d7jmt.yml
@@ -1,0 +1,6 @@
+---
+title: 'Implemented: code to clear the shipments after changing store and logout'
+ticket_id: "#20d7jmt"
+merge_request: 46
+author: Yash Maheshwari
+type: added

--- a/src/store/modules/shipment/actions.ts
+++ b/src/store/modules/shipment/actions.ts
@@ -89,7 +89,7 @@ const actions: ActionTree<ShipmentState, RootState> = {
   },
 
   async clearShipments({ commit }) {
-    commit(types.SHIPMENT_LIST_UPDATED, { shipments: {} })
+    commit(types.SHIPMENT_LIST_UPDATED, { shipments: [] })
     commit(types.SHIPMENT_CURRENT_UPDATED, { current: {} })
   }
 }

--- a/src/store/modules/shipment/actions.ts
+++ b/src/store/modules/shipment/actions.ts
@@ -86,6 +86,11 @@ const actions: ActionTree<ShipmentState, RootState> = {
       emitter.emit("dismissLoader");
       return resp;
     }).catch(err => err);
+  },
+
+  async clearShipments({ commit }) {
+    commit(types.SHIPMENT_LIST_UPDATED, { shipments: {} })
+    commit(types.SHIPMENT_CURRENT_UPDATED, { current: {} })
   }
 }
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -67,6 +67,7 @@ export default defineComponent({
       if(this.userProfile && this.userProfile.facilities) {
         this.userProfile.facilities.map((fac: any) => {
           if (fac.facilityId == facility['detail'].value) {
+            this.store.dispatch('shipment/clearShipments');
             this.store.dispatch('user/setFacility', {'facility': fac});
           }
         })

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -94,6 +94,7 @@ export default defineComponent({
     },
     logout () {
       this.store.dispatch('user/logout').then(() => {
+        this.store.dispatch('shipment/clearShipments');
         this.router.push('/login');
       })
     }


### PR DESCRIPTION
### Related Issues
Shipment list is not getting cleared after logout or changing store.

Closes #

### Short Description and Why It's Useful
Done the changes as this will not show the previous shipments when no shipments found for the current store

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)