### PR TITLE
Fixed: code to add the ion-menu-button on mobile devices(#220kt0h)

### DIFF
--- a/changelogs/unreleased/-220kt0h.yml
+++ b/changelogs/unreleased/-220kt0h.yml
@@ -1,0 +1,6 @@
+---
+title: 'Fixed: code to add the ion-menu-button on mobile devices'
+ticket_id: "#220kt0h"
+merge_request: 51
+author: Yash Maheshwari
+type: other

--- a/src/views/Receiving.vue
+++ b/src/views/Receiving.vue
@@ -2,6 +2,7 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
+        <ion-menu-button slot="start" />
         <ion-title>{{ $t("Receiving") }}</ion-title>
       </ion-toolbar>
     </ion-header>
@@ -23,7 +24,7 @@
 </template>
 
 <script lang="ts">
-import { IonButton, IonContent, IonHeader, IonIcon, IonPage, IonSearchbar, IonTitle, IonToolbar } from '@ionic/vue';
+import { IonButton, IonContent, IonHeader, IonIcon, IonMenuButton, IonPage, IonSearchbar, IonTitle, IonToolbar } from '@ionic/vue';
 import { cloudDownloadOutline } from 'ionicons/icons'
 import { defineComponent } from 'vue'
 import { mapGetters, useStore } from 'vuex'
@@ -36,6 +37,7 @@ export default defineComponent({
     IonContent,
     IonHeader,
     IonIcon,
+    IonMenuButton,
     IonSearchbar,
     IonPage,
     IonTitle,

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -2,6 +2,7 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
+        <ion-menu-button slot="start" />
         <ion-title>{{ $t("Settings") }}</ion-title>
       </ion-toolbar>
     </ion-header>
@@ -33,7 +34,7 @@
 </template>
 
 <script lang="ts">
-import { alertController, IonButton, IonContent, IonHeader,IonIcon, IonItem, IonLabel, IonList, IonPage, IonSelect, IonSelectOption, IonTitle, IonToolbar } from '@ionic/vue';
+import { alertController, IonButton, IonContent, IonHeader,IonIcon, IonItem, IonLabel, IonList, IonMenuButton, IonPage, IonSelect, IonSelectOption, IonTitle, IonToolbar } from '@ionic/vue';
 import { defineComponent } from 'vue';
 import { codeWorkingOutline, ellipsisVertical, personCircleOutline, storefrontOutline} from 'ionicons/icons'
 import { mapGetters, useStore } from 'vuex';
@@ -48,7 +49,8 @@ export default defineComponent({
     IonIcon,
     IonItem, 
     IonLabel,
-    IonList, 
+    IonList,
+    IonMenuButton,
     IonPage, 
     IonSelect, 
     IonSelectOption,


### PR DESCRIPTION
### Related Issues
Unable to switch screen when on mobile devices

Closes #

### Short Description and Why It's Useful
Added the ion-menu-button component on the screens

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
After:
![image](https://user-images.githubusercontent.com/41404838/153992292-679d9957-b3a4-446b-b1fb-99681a1537cc.png)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)