### PR TITLE
Fixed: Logic to recieveAll returns on return-details page(#2t2wcjr)

### DIFF
--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -175,9 +175,8 @@ export default defineComponent({
       return alert.present();
     },
     async receiveReturn() {
-      await this.store.dispatch('return/receiveReturn', {payload: this.current}).then(() => {
-        this.router.push('/returns');
-      })   
+      await this.store.dispatch('return/receiveReturn', {payload: this.current});
+      this.router.push('/returns');
     },
     receiveAll(item: any) {
       this.current.items.find((ele: any) => {

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -180,7 +180,7 @@ export default defineComponent({
       })   
     },
     receiveAll(item: any) {
-      this.current.items.filter((ele: any) => {
+      this.current.items.find((ele: any) => {
         if(ele.itemSeqId == item.itemSeqId) {
           ele.quantityAccepted = ele.quantityOrdered;
           ele.progress = ele.quantityAccepted / ele.quantityOrdered

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -184,6 +184,7 @@ export default defineComponent({
         if(ele.itemSeqId == item.itemSeqId) {
           ele.quantityAccepted = ele.quantityOrdered;
           ele.progress = ele.quantityAccepted / ele.quantityOrdered
+          return;
         }
       })
     },

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -89,6 +89,7 @@ import Image from "@/components/Image.vue";
 import { useRouter } from 'vue-router';
 import Scanner from "@/components/Scanner.vue";
 import ImageModal from '@/components/ImageModal.vue';
+import { hasError } from '@/utils';
 
 export default defineComponent({
   name: "ReturnDetails",
@@ -175,15 +176,17 @@ export default defineComponent({
       return alert.present();
     },
     async receiveReturn() {
-      await this.store.dispatch('return/receiveReturn', {payload: this.current});
-      this.router.push('/returns');
+      let resp = await this.store.dispatch('return/receiveReturn', {payload: this.current});
+      if(resp.status === 200 && !hasError(resp)) {
+        this.router.push('/returns');
+      }
     },
     receiveAll(item: any) {
-      this.current.items.find((ele: any) => {
+      let element = this.current.items.find((ele: any) => {
         if(ele.itemSeqId == item.itemSeqId) {
-          ele.quantityAccepted = ele.quantityOrdered;
-          ele.progress = ele.quantityAccepted / ele.quantityOrdered
-          return;
+          element.quantityAccepted = ele.quantityOrdered;
+          element.progress = ele.quantityAccepted / ele.quantityOrdered
+          return element;
         }
       })
     },


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When we want to receive all return shipments, we always will get one item, so its unnecessary to use filter and loop over whole current items array. So we will use find here so as soon as we meet the condition, it returns without looping over array.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)