### PR TITLE
Fixed: code to not change the route when one of the return shipment item api fails and also change the default href for details page

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -8,6 +8,7 @@
   "Complete": "Complete",
   "External ID": "External ID",
   "Location": "Location",
+  "Failed to receive some of the items": "Failed to receive some of the items",
   "facility location": "facility location",
   "Facility locations were not found corresponding to destination facility of return shipment. Please add facility locations to avoid receive return shipment failure.": "Facility locations were not found corresponding to destination facility of return shipment. Please add facility locations to avoid receive return shipment failure.",
   "eCom Store": "eCom Store",

--- a/src/store/modules/return/actions.ts
+++ b/src/store/modules/return/actions.ts
@@ -122,18 +122,19 @@ const actions: ActionTree<ReturnState, RootState> = {
         unitCost: 0.00,
         locationSeqId: item.locationSeqId
       }
-      const resp = await ReturnService.receiveReturnItem(params);
-
-      if(resp.status === 200 && !hasError(resp)){
-       return Promise.resolve(resp);
-      } else {
-       return Promise.reject(resp);
-      } 
+      return ReturnService.receiveReturnItem(params).catch((err) => err)
     }))
   },
   async receiveReturn ({ dispatch }, {payload}) {
     emitter.emit("presentLoader");
-    return await dispatch("receiveReturnItem", payload).then(async () => {
+    return await dispatch("receiveReturnItem", payload).then(async (response: any) => {
+
+      if (response.some((res: any) => res.status !== 200 || hasError(res))) {
+        showToast(translate('Failed to receive some of the items'));
+        emitter.emit("dismissLoader");
+        return;
+      }
+
       const resp = await ReturnService.receiveReturn({
         "shipmentId": payload.shipmentId,
         "statusId": "PURCH_SHIP_RECEIVED"

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button default-href="/" slot="start"></ion-back-button>
+        <ion-back-button default-href="/returns" slot="start"></ion-back-button>
         <ion-title>{{ $t("Return Details") }}</ion-title>
       </ion-toolbar>
     </ion-header>

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -222,9 +222,12 @@ export default defineComponent({
       return alert.present();
     },
     async receiveReturn() {
-      await this.store.dispatch('return/receiveReturn', {payload: this.current}).then(() => {
-        this.router.push('/returns');
-      })   
+      await this.store.dispatch('return/receiveReturn', {payload: this.current}).then((resp) => {
+        // Only change the route when getting success from api resp
+        if (resp?.status === 200) {
+          this.router.push('/returns');
+        }
+      })
     },
     receiveAll(item: any) {
       this.current.items.filter((ele: any) => {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
- When a return item api fails then also the return shipment gets received
- On refresh on details page, and then clicking on back button redirects to shipment page

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added code to check that if any of the api for items fails, then not receiving the return shipment and displaying error toast
- Changed default href on details page

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)