### PR TITLE
Improved: PurchaseOrders, Returns, Shipments page with autofocus on searchbar(#2vd9jaf)

### DIFF
--- a/src/views/PurchaseOrders.vue
+++ b/src/views/PurchaseOrders.vue
@@ -8,7 +8,7 @@
     </ion-header>
     <ion-content>
       <main>
-        <ion-searchbar :placeholder="$t('Search purchase orders')" v-model="queryString" @keyup.enter="queryString = $event.target.value; getPurchaseOrders()" />
+        <ion-searchbar ref="searchbarRef" :placeholder="$t('Search purchase orders')" v-model="queryString" @keyup.enter="queryString = $event.target.value; getPurchaseOrders()" />
 
         <PurchaseOrderItem v-for="(order, index) in orders" :key="index" :purchaseOrder="order.doclist.docs[0]" />
         
@@ -92,6 +92,10 @@ export default defineComponent({
   },
   mounted () {
     this.getPurchaseOrders();
+    const focusSearchBar = this.$refs.searchbarRef as any;
+    setTimeout(() => {
+      focusSearchBar.$el.setFocus();
+    }, 300);
   },
   setup () {
     const store = useStore();

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button default-href="/returns" slot="start"></ion-back-button>
+        <ion-back-button default-href="/returns" slot="start" />
         <ion-title>{{ $t("Return Details") }}</ion-title>
       </ion-toolbar>
     </ion-header>
@@ -25,7 +25,7 @@
         <div class="scanner">
           <ion-item>
             <ion-label>{{ $t("Scan items") }}</ion-label>
-            <ion-input :placeholder="$t('Scan barcodes to receive them')" v-model="queryString" @keyup.enter="updateProductCount()" />
+            <ion-input ref="searchbarRef" :placeholder="$t('Scan barcodes to receive them')" v-model="queryString" @keyup.enter="updateProductCount()" />
           </ion-item>
 
           <ion-button expand="block" fill="outline" @click="scanCode()">
@@ -161,6 +161,9 @@ export default defineComponent({
     if(!this.isReturnReceivable(current.statusId)) {
       showToast(translate("This return has been and cannot be edited.", { status: current?.statusDesc?.toLowerCase() }));
     }
+
+    const focusSearchBar = this.$refs.searchbarRef as any;
+    focusSearchBar.$el.setFocus();
   },
   computed: {
     ...mapGetters({

--- a/src/views/Returns.vue
+++ b/src/views/Returns.vue
@@ -56,13 +56,13 @@ export default defineComponent({
   },
   mounted () {
     this.store.dispatch('return/fetchValidReturnStatuses');
+    this.getReturns();
+  },
+  ionViewDidEnter(){
     const focusSearchBar = this.$refs.searchbarRef as any;
     setTimeout(() => {
       focusSearchBar.$el.setFocus();
     }, 300);
-  },
-  ionViewDidEnter(){
-    this.getReturns();
   },
   methods: {
     async getReturns(vSize?: any, vIndex?: any) {

--- a/src/views/Returns.vue
+++ b/src/views/Returns.vue
@@ -8,7 +8,7 @@
     </ion-header>
     <ion-content>
       <main>
-        <ion-searchbar :placeholder="$t('Scan ASN to start receiving')" v-model="queryString" @keyup.enter="queryString = $event.target.value; getReturns()" />
+        <ion-searchbar ref="searchbarRef" :placeholder="$t('Scan ASN to start receiving')" v-model="queryString" @keyup.enter="queryString = $event.target.value; getReturns()" />
   
         <ReturnListItem v-for="returnShipment in returns" :key="returnShipment.shipmentId" :returnShipment="returnShipment" />
 
@@ -56,6 +56,10 @@ export default defineComponent({
   },
   mounted () {
     this.store.dispatch('return/fetchValidReturnStatuses');
+    const focusSearchBar = this.$refs.searchbarRef as any;
+    setTimeout(() => {
+      focusSearchBar.$el.setFocus();
+    }, 300);
   },
   ionViewDidEnter(){
     this.getReturns();

--- a/src/views/Shipments.vue
+++ b/src/views/Shipments.vue
@@ -8,7 +8,7 @@
     </ion-header>
     <ion-content>
       <main>
-        <ion-searchbar :placeholder="$t('Scan ASN to start receiving')" v-model="queryString" @keyup.enter="queryString = $event.target.value; getShipments()" />
+        <ion-searchbar ref="searchbarRef" :placeholder="$t('Scan ASN to start receiving')" v-model="queryString" @keyup.enter="queryString = $event.target.value; getShipments()" />
 
         <ShipmentListItem v-for="shipment in shipments" :key="shipment.shipmentId" :shipment="shipment"/>
 
@@ -57,6 +57,10 @@ export default defineComponent({
   },
   mounted () {
     this.getShipments();
+    const focusSearchBar = this.$refs.searchbarRef as any;
+    setTimeout(() => {
+      focusSearchBar.$el.setFocus();
+    }, 300);
   },
   methods: {
     selectSearchBarText(event: any) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #133 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Whenever someone will open PurchaseOrders, Returns or Shipments page, searchbar will be in focus automatically, also tab indexing is working, if we press tab when focused on searchbar, focus will move to products lists & on pressing enter we can move to details page respectively.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

https://user-images.githubusercontent.com/62360781/192787972-966778be-8594-42fa-b330-952a71fd2c24.mov



**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)