### PR TITLE
Fixed: Shipment count not being updated on the Shipments page on  adding an item from Shipment details page. (#2u59n2d)

### DIFF
--- a/src/store/modules/shipment/actions.ts
+++ b/src/store/modules/shipment/actions.ts
@@ -137,8 +137,8 @@ const actions: ActionTree<ShipmentState, RootState> = {
   async updateProductCount({ commit, state }, payload ) {
     const shipments = state.shipments.list;
     shipments.forEach((shipment: any) => {
-      if(shipment.id === payload.shipmentId) {
-        shipment.noOfItem = parseInt(shipment.noOfItem) + 1;
+      if(shipment.shipmentId === payload.shipmentId) {
+        shipment.shipmentItemCount = parseInt(shipment.shipmentItemCount) + 1;
         return;
       }
     })


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Shipment count on wasn't updated when you add an item to the shipment.
- Refresh was needed for the change to take place initially. 
- The issue was there due to wrong variable names in the respective action updateProductCount.
- Changing the names to the ones matching the API response and with the one used in ShipmentListItem fixed the issue.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)