### PR TITLE
Implemented: feature to copy internal id to clipboard on the detail page for POs

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,6 @@
 import { toastController } from '@ionic/vue';
+import { translate } from '@/i18n'
+import { Plugins } from '@capacitor/core';
 
 // TODO Use separate files for specific utilities
 
@@ -17,4 +19,14 @@ const showToast = async (message: string) => {
       return toast.present();
 }
 
-export { showToast, hasError }
+const copyToClipboard = async (text: string) => {
+    const { Clipboard } = Plugins;
+
+    await Clipboard.write({
+      string: text,
+    }).then(() => {
+        showToast(translate("Copied", { text }));
+    });
+}
+
+export { showToast, hasError, copyToClipboard }

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -23,7 +23,7 @@
           </ion-item>
           
           <div class="doc-meta">
-            <ion-chip>{{ order.orderId }}</ion-chip>
+            <ion-chip @click="copyOrderIdToClipboard">{{ order.orderId }}<ion-icon :icon="copy"/></ion-chip>
           </div>
         </div>
         
@@ -125,7 +125,7 @@ import {
   popoverController
 } from '@ionic/vue';
 import { defineComponent } from 'vue';
-import { addOutline, cameraOutline, checkmarkDone, saveOutline, timeOutline } from 'ionicons/icons';
+import { addOutline, cameraOutline, checkmarkDone, saveOutline, timeOutline, copy } from 'ionicons/icons';
 import ReceivingHistoryModal from '@/views/ReceivingHistoryModal.vue'
 import Image from "@/components/Image.vue";
 import { useStore, mapGetters } from 'vuex';
@@ -134,6 +134,8 @@ import Scanner from "@/components/Scanner.vue"
 import AddProductToPOModal from '@/views/AddProductToPOModal.vue'
 import LocationPopover from '@/components/LocationPopover.vue'
 import ImageModal from '@/components/ImageModal.vue';
+import { Plugins } from '@capacitor/core';
+const { Clipboard } = Plugins;
 
 export default defineComponent({
   name: "PurchaseOrderDetails",
@@ -245,6 +247,11 @@ export default defineComponent({
           ele.progress = ele.quantityAccepted / ele.quantity;
         }
       })
+    },
+    copyOrderIdToClipboard() {
+      Clipboard.write({
+        string: this.order.orderId,
+      });
     }
   }, 
   ionViewWillEnter() {
@@ -263,7 +270,8 @@ export default defineComponent({
       router,
       saveOutline,
       store,
-      timeOutline
+      timeOutline,
+      copy
     };
   },
 });

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -23,7 +23,7 @@
           </ion-item>
           
           <div class="doc-meta">
-            <ion-chip @click="copyToClipboard(order.orderId)">{{ order.orderId }}<ion-icon :icon="copy-outline"/></ion-chip>
+            <ion-chip @click="copyToClipboard(order.orderId)">{{ order.orderId }}<ion-icon :icon="copyOutline"/></ion-chip>
           </div>
         </div>
         

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -23,7 +23,7 @@
           </ion-item>
           
           <div class="doc-meta">
-            <ion-chip @click="copyOrderIdToClipboard">{{ order.orderId }}<ion-icon :icon="copy"/></ion-chip>
+            <ion-chip @click="copyOrderIdToClipboard">{{ order.orderId }}<ion-icon :icon="copy-outline"/></ion-chip>
           </div>
         </div>
         

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -23,7 +23,7 @@
           </ion-item>
           
           <div class="doc-meta">
-            <ion-chip @click="copyOrderIdToClipboard">{{ order.orderId }}<ion-icon :icon="copy-outline"/></ion-chip>
+            <ion-chip @click="copyToClipboard(order.orderId)">{{ order.orderId }}<ion-icon :icon="copy-outline"/></ion-chip>
           </div>
         </div>
         
@@ -125,7 +125,7 @@ import {
   popoverController
 } from '@ionic/vue';
 import { defineComponent } from 'vue';
-import { addOutline, cameraOutline, checkmarkDone, saveOutline, timeOutline, copy } from 'ionicons/icons';
+import { addOutline, cameraOutline, checkmarkDone, saveOutline, timeOutline, copyOutline } from 'ionicons/icons';
 import ReceivingHistoryModal from '@/views/ReceivingHistoryModal.vue'
 import Image from "@/components/Image.vue";
 import { useStore, mapGetters } from 'vuex';
@@ -246,9 +246,6 @@ export default defineComponent({
           ele.progress = ele.quantityAccepted / ele.quantity;
         }
       })
-    },
-    copyOrderIdToClipboard() {
-      copyToClipboard(this.order.orderId);
     }
   }, 
   ionViewWillEnter() {
@@ -264,11 +261,11 @@ export default defineComponent({
       addOutline,
       cameraOutline,
       checkmarkDone,
+      copyOutline,
       router,
       saveOutline,
       store,
-      timeOutline,
-      copy
+      timeOutline
     };
   },
 });

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -262,6 +262,7 @@ export default defineComponent({
       cameraOutline,
       checkmarkDone,
       copyOutline,
+      copyToClipboard,
       router,
       saveOutline,
       store,

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -134,8 +134,7 @@ import Scanner from "@/components/Scanner.vue"
 import AddProductToPOModal from '@/views/AddProductToPOModal.vue'
 import LocationPopover from '@/components/LocationPopover.vue'
 import ImageModal from '@/components/ImageModal.vue';
-import { Plugins } from '@capacitor/core';
-const { Clipboard } = Plugins;
+import { copyToClipboard } from '@/utils';
 
 export default defineComponent({
   name: "PurchaseOrderDetails",
@@ -249,9 +248,7 @@ export default defineComponent({
       })
     },
     copyOrderIdToClipboard() {
-      Clipboard.write({
-        string: this.order.orderId,
-      });
+      copyToClipboard(this.order.orderId);
     }
   }, 
   ionViewWillEnter() {


### PR DESCRIPTION
### Related Issues
Closes #153

### Short Description and Why It's Useful

- Adds copy icon on order id chip of PurchaseOrderDetail
- Uses @capacitor plugin to copy to clipboard

### Screenshots of Visual Changes before/after (If There Are Any)
![image](https://user-images.githubusercontent.com/15387723/195948478-8e1dc559-c94f-4714-a924-3704b92e0f28.png)

**IMPORTANT NOTICE** - Remember to add changelog entry
Did not found how I could have done that, if instructions are provided I'd be welcome

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)