### PR TITLE
Fixed: Displaying toast message when no orders found on clicking Load more Purchase orders (#2vjux71)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -16,7 +16,7 @@ const actions: ActionTree<OrderState, RootState> = {
     try {
       resp = await OrderService.fetchPurchaseOrders(payload)
 
-      if (resp.status === 200 && !hasError(resp) && resp.data.grouped && resp.data.grouped.orderId.groups?.length > 0) {
+      if (resp.status === 200 && !hasError(resp) && resp.data.grouped?.orderId.groups?.length > 0) {
         const orders = resp.data.grouped.orderId
         
         orders.groups.forEach((order: any) => {

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -16,7 +16,7 @@ const actions: ActionTree<OrderState, RootState> = {
     try {
       resp = await OrderService.fetchPurchaseOrders(payload)
 
-      if (resp.status === 200 && !hasError(resp) && resp.data.grouped) {
+      if (resp.status === 200 && !hasError(resp) && resp.data.grouped && resp.data.grouped.orderId.groups.length > 0) {
         const orders = resp.data.grouped.orderId
         
         orders.groups.forEach((order: any) => {

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -16,7 +16,7 @@ const actions: ActionTree<OrderState, RootState> = {
     try {
       resp = await OrderService.fetchPurchaseOrders(payload)
 
-      if (resp.status === 200 && !hasError(resp) && resp.data.grouped && resp.data.grouped.orderId.groups.length > 0) {
+      if (resp.status === 200 && !hasError(resp) && resp.data.grouped && resp.data.grouped.orderId.groups?.length > 0) {
         const orders = resp.data.grouped.orderId
         
         orders.groups.forEach((order: any) => {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #137 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixes toast message not being displayed when no orders exist and the user clicks Load more orders button.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)