### PR TITLE
Implemented: showing receiving history upon clicking on shipment item 'received' chip (#85zrhcn67)

### DIFF
--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -209,7 +209,7 @@ export default defineComponent({
       })  
       return modal.present();
     },
-    async receivingHistory(productId?: any) {
+    async receivingHistory(productId?: string) {
       const modal = await modalController
         .create({
           component: ReceivingHistoryModal,

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -5,7 +5,7 @@
         <ion-back-button default-href="/purchase-orders" slot="start" />
         <ion-title> {{$t("Purchase Order Details")}} </ion-title>
         <ion-buttons slot="end">
-          <ion-button @click="receivingHistory">
+          <ion-button @click="receivingHistory()">
             <ion-icon slot="icon-only" :icon="timeOutline"/>
           </ion-button>
           <ion-button @click="addProduct">
@@ -76,7 +76,7 @@
             </div>
 
             <div class="po-item-history">
-              <ion-chip outline>
+              <ion-chip outline @click="receivingHistory(item.productId)">
                 <ion-icon :icon="checkmarkDone"/>
                 <ion-label> {{ getPOItemAccepted(item.productId) }} {{ $t("received") }} </ion-label>
               </ion-chip>
@@ -209,11 +209,11 @@ export default defineComponent({
       })  
       return modal.present();
     },
-    async receivingHistory() {
+    async receivingHistory(productId?: any) {
       const modal = await modalController
         .create({
           component: ReceivingHistoryModal,
-          componentProps: {order: this.order}
+          componentProps: {productId}
         })
       return modal.present();
     },

--- a/src/views/ReceivingHistoryModal.vue
+++ b/src/views/ReceivingHistoryModal.vue
@@ -10,7 +10,7 @@
     </ion-toolbar>
   </ion-header>
   <ion-content>
-    <ion-list v-for="(item, index) in poHistory.items" :key="index">
+    <ion-list v-for="(item, index) in items" :key="index">
       <ion-item>
         <ion-thumbnail slot="start">
           <Image :src="getProduct(item.productId).mainImageUrl" />
@@ -66,7 +66,15 @@ export default defineComponent({
     IonTitle,
     IonToolbar,
   },
-  props: ["order"],
+  data() {
+    return {
+      items: []
+    }
+  },
+  props: ["productId"],
+  mounted() {
+    this.items = this.productId ? this.poHistory.items.filter(item => item.productId === this.productId) : this.poHistory.items;
+  },
   computed: {
     ...mapGetters({
       poHistory: 'order/getPOHistory',


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #151 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Upon clicking the 'received' chip on the PO details page, the receiving history of that shipment item will be shown in the modal.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

https://user-images.githubusercontent.com/59442907/210532465-9f04b53b-5d8e-4da9-943e-1464286570e8.webm

**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)