### PR TITLE
[WIP] Order name is primary info

### DIFF
--- a/src/components/PurchaseOrderItem.vue
+++ b/src/components/PurchaseOrderItem.vue
@@ -2,8 +2,8 @@
   <ion-item button @click="getOrderDetail(purchaseOrder.orderId)">
     <ion-label>
       <!-- TODO:- Handle this purchase order number property for now i have used OrderName or OrderId -->
-      <h3>{{ purchaseOrder.externalOrderId }}</h3>
-      <p>{{ purchaseOrder.orderName ? purchaseOrder.orderName : purchaseOrder.orderId }}</p>
+      <h3>{{ purchaseOrder.orderName ? purchaseOrder.orderName : purchaseOrder.orderId }}</h3>
+      <p>{{ purchaseOrder.orderId }}</p>
     </ion-label>
     <ion-label class="ion-text-end" slot="end">
       <p>{{ purchaseOrder.estimatedDeliveryDate ? $filters.formatUtcDate(purchaseOrder.estimatedDeliveryDate, 'YYYY-MM-DDTHH:mm:ssZ') : " - " }}</p>


### PR DESCRIPTION
The order name should be in the primary information slot and the secondary <p> containing the internal ID should only be visible if the order name is not the internal ID.

@k2maan I have put the order name in the primary slot but you will have to carry it forward from here.

h3: Order name
p: Order ID, only visible if order id is different from order name