### PR TITLE
Improved: Displayed External Order ID on Shipments page. Also enabled search on the same. (249)

### DIFF
--- a/src/components/ShipmentListItem.vue
+++ b/src/components/ShipmentListItem.vue
@@ -1,6 +1,7 @@
 <template>
   <ion-item button @click="viewShipment()">
     <ion-label>
+      <p class="overline" v-show="shipment.shipmentTypeId == 'IN_TRANSFER' && shipment.externalOrderId">{{ shipment.externalOrderId }}</p>
       <h2>{{ shipment.externalId ? shipment.externalId : shipment.shipmentId }}</h2>
       <p v-if="shipment.shipmentItemCount">{{ shipment.shipmentItemCount }} {{ (shipment.shipmentItemCount > 1 ? 'Items' : 'Item') }}</p>
     </ion-label>

--- a/src/components/ShipmentListItem.vue
+++ b/src/components/ShipmentListItem.vue
@@ -1,7 +1,7 @@
 <template>
   <ion-item button @click="viewShipment()">
     <ion-label>
-      <p class="overline" v-show="shipment.shipmentTypeId == 'IN_TRANSFER' && shipment.externalOrderId">{{ shipment.externalOrderId }}</p>
+      <p class="overline" v-show="shipment.externalOrderId">{{ shipment.externalOrderId }}</p>
       <h2>{{ shipment.externalId ? shipment.externalId : shipment.shipmentId }}</h2>
       <p v-if="shipment.shipmentItemCount">{{ shipment.shipmentItemCount }} {{ (shipment.shipmentItemCount > 1 ? 'Items' : 'Item') }}</p>
     </ion-label>

--- a/src/store/modules/shipment/actions.ts
+++ b/src/store/modules/shipment/actions.ts
@@ -11,6 +11,7 @@ const actions: ActionTree<ShipmentState, RootState> = {
   async findShipment ({ commit, state }, payload) {
     let resp;
     try {
+      console.log("========payload==", payload);
       resp = await ShipmentService.fetchShipments(payload)
       if (resp.status === 200 && resp.data.docs?.length > 0 && !hasError(resp)) {
         let shipments = resp.data.docs;

--- a/src/store/modules/shipment/actions.ts
+++ b/src/store/modules/shipment/actions.ts
@@ -11,7 +11,6 @@ const actions: ActionTree<ShipmentState, RootState> = {
   async findShipment ({ commit, state }, payload) {
     let resp;
     try {
-      console.log("========payload==", payload);
       resp = await ShipmentService.fetchShipments(payload)
       if (resp.status === 200 && resp.data.docs?.length > 0 && !hasError(resp)) {
         let shipments = resp.data.docs;

--- a/src/views/Shipments.vue
+++ b/src/views/Shipments.vue
@@ -97,15 +97,20 @@ export default defineComponent({
           "parentTypeId_fld0_grp": "2",
         },
         "entityName": "ShipmentAndTypeAndItemCount",
-        "fieldList" : [ "shipmentId","primaryShipGroupSeqId","partyIdFrom","partyIdTo","estimatedArrivalDate","destinationFacilityId","statusId", "shipmentItemCount", "externalId" ],
+        "fieldList" : [ "shipmentId","primaryShipGroupSeqId","partyIdFrom","partyIdTo","estimatedArrivalDate","destinationFacilityId","statusId", "shipmentItemCount", "externalId", "externalOrderId", "shipmentTypeId" ],
         "noConditionFind": "Y",
         "viewSize": viewSize,
         "viewIndex": viewIndex,
       } as any
       if(this.queryString){
-        payload.inputFields["shipmentId"] = this.queryString;
-        payload.inputFields["shipmentId_op"] = "contains";
-        payload.inputFields["shipmentId_ic"] = "Y";
+          payload.inputFields["shipmentId_value"] = this.queryString
+          payload.inputFields["shipmentId_op"] = 'contains'
+          payload.inputFields["shipmentId_ic"] = 'Y'
+          payload.inputFields["shipmentId_grp"] = '1'
+          payload.inputFields["externalOrderId_value"] = this.queryString
+          payload.inputFields["externalOrderId_op"] = 'contains'
+          payload.inputFields["externalOrderId_ic"] = 'Y'
+          payload.inputFields["externalOrderId_grp"] = '2'
       }
       await this.store.dispatch("shipment/findShipment", payload);
     },


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #249 

### Short Description and Why It's Useful
Improved: Displayed External Order ID (Transfer Order # in case of transfer shipment from Netsuite) on Shipments page. Also enabled search on the same. (249)

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)