### PR TITLE
Implemented: Page Selection Persistence for Receiving App with Side Navigation(#122)

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -9,7 +9,7 @@
     <ion-content>
       <ion-list id="receiving-list">
         <ion-menu-toggle auto-hide="false" v-for="(p, i) in appPages" :key="i">
-          <ion-item button @click="selectedIndex = i" router-direction="root" :router-link="p.url" class="hydrated" :class="{ selected: selectedIndex === i }">
+          <ion-item button router-direction="root" :router-link="p.url" class="hydrated" :class="{ selected: selectedIndex === i }">
             <ion-icon slot="start" :ios="p.iosIcon" :md="p.mdIcon" />
             <ion-label>{{ p.title }}</ion-label>
           </ion-item>
@@ -32,10 +32,11 @@ import {
   IonMenu,
   IonMenuToggle,
 } from "@ionic/vue";
-import { defineComponent, ref } from "vue";
+import { computed, defineComponent } from "vue";
 import { mapGetters } from "vuex";
 import { calendar, download, gitPullRequestOutline, settings } from "ionicons/icons";
 import { useStore } from "@/store";
+import { useRouter } from "vue-router";
 
 export default defineComponent({
   name: "Menu",
@@ -51,29 +52,15 @@ export default defineComponent({
     IonMenu,
     IonMenuToggle,
   },
-  created() {
-    // When open any specific page it should show that page selected
-    this.selectedIndex = this.appPages.findIndex((page) => {
-      return page.url === this.$router.currentRoute.value.path;
-    })
-  },
   computed: {
     ...mapGetters({
       isUserAuthenticated: 'user/isUserAuthenticated',
       currentFacility: 'user/getCurrentFacility',
     })
   },
-  watch:{
-    $route (to) {
-      // When logout and login it should point to Oth index
-      if (to.path === '/login') {
-        this.selectedIndex = 0;
-      }
-    },
-  }, 
   setup() {
     const store = useStore();
-    const selectedIndex = ref(0);
+    const router = useRouter();
     const appPages = [
       {
         title: "Shipments",
@@ -99,7 +86,13 @@ export default defineComponent({
         iosIcon: settings,
         mdIcon: settings,
       }
-    ];
+    ] as any;
+
+    const selectedIndex = computed(() => {
+      const path = router.currentRoute.value.path
+      return appPages.findIndex((screen: any) => screen.url === path || screen.childRoutes?.includes(path))
+    })
+
     return {
       selectedIndex,
       appPages,
@@ -108,7 +101,7 @@ export default defineComponent({
       store,
       calendar
     };
-  },
+  }
 });
 </script>
 

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -65,18 +65,21 @@ export default defineComponent({
       {
         title: "Shipments",
         url: "/shipments",
+        childRoutes: ["/shipment/"],
         iosIcon: download,
         mdIcon: download,
       },
       {
         title: "Returns",
         url: "/returns",
+        childRoutes: ["/return/"],
         iosIcon: gitPullRequestOutline,
         mdIcon: gitPullRequestOutline,
       },
       {
         title: "Purchase Orders",
         url: "/purchase-orders",
+        childRoutes: ["/purchase-order-detail/"],
         iosIcon: calendar,
         mdIcon: calendar
       },
@@ -86,11 +89,11 @@ export default defineComponent({
         iosIcon: settings,
         mdIcon: settings,
       }
-    ] as any;
+    ];
 
     const selectedIndex = computed(() => {
       const path = router.currentRoute.value.path
-      return appPages.findIndex((screen: any) => screen.url === path || screen.childRoutes?.includes(path))
+      return appPages.findIndex((screen) => screen.url === path || screen.childRoutes?.includes(path) || screen.childRoutes?.some((route) => path.includes(route)))
     })
 
     return {


### PR DESCRIPTION
### Related Issues
Related Issue: https://github.com/hotwax/dxp-components/issues/122

### Short Description and Why It's Useful
Fixed issue of menu not being enabled for the correct page when using the back button in Receiving app.

- Removed a watcher from the menu component that checks for route changes
- Defined a computed property to find the correct index in the menu list
- Added an entry in the menu component pages to list all the child routes those are not listed in the menu for a specific parent route, using which we have enabled the correct menu in the UI.
- Added a logic for the dynamic child routes in the app.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)