### PR TITLE
Improved: Displayed Tracking ID Number and External Order ID on the shipment detail page.

### DIFF
--- a/src/views/ShipmentDetails.vue
+++ b/src/views/ShipmentDetails.vue
@@ -14,9 +14,9 @@
       <main>
         <ion-item lines="none">
           <ion-label>
-          <p class="overline" v-show="current.externalOrderId">{{ current.externalOrderId }}</p>
-          <h1 v-if="current.externalId">{{ $t("External ID") }}: {{ current.externalId }}</h1>
-          <h1 v-else>{{ $t("Shipment ID") }}: {{ current.shipmentId }}</h1>
+            <p class="overline" v-show="current.externalOrderId">{{ current.externalOrderId }}</p>
+            <h1 v-if="current.externalId">{{ $t("External ID") }}: {{ current.externalId }}</h1>
+            <h1 v-else>{{ $t("Shipment ID") }}: {{ current.shipmentId }}</h1>
           </ion-label>
           <ion-chip v-show="current.trackingIdNumber">{{current.trackingIdNumber}}</ion-chip>
         </ion-item>

--- a/src/views/ShipmentDetails.vue
+++ b/src/views/ShipmentDetails.vue
@@ -13,8 +13,12 @@
     <ion-content>
       <main>
         <ion-item lines="none">
+          <ion-label>
+          <p class="overline" v-show="current.externalOrderId">{{ current.externalOrderId }}</p>
           <h1 v-if="current.externalId">{{ $t("External ID") }}: {{ current.externalId }}</h1>
           <h1 v-else>{{ $t("Shipment ID") }}: {{ current.shipmentId }}</h1>
+          </ion-label>
+          <ion-chip v-show="current.trackingIdNumber">{{current.trackingIdNumber}}</ion-chip>
         </ion-item>
 
         <div class="scanner">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #250

### Short Description and Why It's Useful
Improved: Displayed Tracking ID Number and External Order ID on the shipment detail page.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)