### PR TITLE
Fixed: error handling in login process in case of object in error (dxp-258)

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -97,7 +97,7 @@ const actions: ActionTree<UserState, RootState> = {
       // TODO Check if handling of specific status codes is required.
       showToast(translate('Something went wrong while login. Please contact administrator'));
       console.error("error", err);
-      return Promise.reject(new Error(err))
+      return Promise.reject(err instanceof Object ? err : new Error(err))
     }
   },
 


### PR DESCRIPTION
### Related Issues
 <!--  Put related issue number which this PR is closing. For example #123 -->
https://github.com/hotwax/dxp-components/issues/258
 Closes #

 ### Short Description and Why It's Useful
 <!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed error handling in login process to avoid showing Object if error is an Object.

 ### Screenshots of Visual Changes before/after (If There Are Any)
 <!-- If you made any changes in the UI layer, please provide before/after screenshots -->
 Before :
![302584235-dd9cc119-4843-4879-a571-c8b1cb17b873](https://github.com/hotwax/facilities/assets/83332530/7760b8fe-eb1b-449f-955e-c05a74b4b7c9)
After :
![image](https://github.com/hotwax/threshold-management/assets/83332530/00c03fa5-a47f-442d-9f56-608b00f7f9fb)


 **IMPORTANT NOTICE** - Remember to add changelog entry


 ### Contribution and Currently Important Rules Acceptance
 <!-- Please get familiar with following info -->

 - [x] I read and followed [contribution rules](https://github.com/hotwax/threshold-management#contribution-guideline)