### PR TITLE
Fixed: scanning failure issue caused by empty quantity values when scanning barcode  #308

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -41,11 +41,13 @@ const actions: ActionTree<OrderState, RootState> = {
     return resp;
   },
   async updateProductCount({ commit, state }, payload ) {
-    state.current.items.find((item: any) => {
-      if (item.internalName === payload) {
-        item.quantityAccepted = item.quantityAccepted + 1;
-      }
-    });
+    const item = state.current.items.find((item: any)=> item.internalName === payload);
+    if (item) {
+      item.quantityAccepted = item.quantityAccepted ? parseInt(item.quantityAccepted) + 1 : parseInt("0") + 1;
+    } else {
+      showToast(translate("Product not found"));
+    }
+    
     commit(types.ORDER_CURRENT_UPDATED, state.current )
   },
   async addOrderItem ({ commit }, payload) {

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -41,9 +41,9 @@ const actions: ActionTree<OrderState, RootState> = {
     return resp;
   },
   async updateProductCount({ commit, state }, payload ) {
-    const item = state.current.items.find((item: any)=> item.internalName === payload);
+    const item = state.current.items.find((item: any) => item.internalName === payload);
     if (item) {
-      item.quantityAccepted = item.quantityAccepted ? parseInt(item.quantityAccepted) + 1 : parseInt("0") + 1;
+      item.quantityAccepted = item.quantityAccepted ? parseInt(item.quantityAccepted) + 1 : 1;
     } else {
       showToast(translate("Product not found"));
     }

--- a/src/store/modules/return/actions.ts
+++ b/src/store/modules/return/actions.ts
@@ -33,11 +33,13 @@ const actions: ActionTree<ReturnState, RootState> = {
     return resp;
   },
   async updateReturnProductCount ({ commit, state }, payload) {
-    await state.current.items.find((item: any) => {
-      if(item.sku === payload){
-        item.quantityAccepted = parseInt(item.quantityAccepted) + 1;
-      }
-    });
+    const item = state.current.items.find((item: any) => item.sku === payload);
+    if (item) {
+      item.quantityAccepted = item.quantityAccepted ? parseInt(item.quantityAccepted) + 1 : 1;
+    } else {
+      showToast(translate("Product not found"));
+    }
+
     commit(types.RETURN_CURRENT_UPDATED, state);
   },
   async setCurrent ({ commit, state }, payload) {

--- a/src/store/modules/shipment/actions.ts
+++ b/src/store/modules/shipment/actions.ts
@@ -6,6 +6,7 @@ import * as types from './mutation-types'
 import { hasError, showToast } from '@/utils'
 import { translate } from '@hotwax/dxp-components'
 import emitter from '@/event-bus'
+import { Item } from "@ionic/core/dist/types/components/item/item";
 
 const actions: ActionTree<ShipmentState, RootState> = {
   async findShipment ({ commit, state }, payload) {
@@ -34,13 +35,9 @@ const actions: ActionTree<ShipmentState, RootState> = {
   },
 
   async updateShipmentProductCount ({ commit, state }, payload) {
-    const findItem = state.current.items.find((item:any) => item.sku === payload);
-
-    if (findItem ) {
-      if (findItem.quantityAccepted === "") {
-        findItem.quantityAccepted = 0;
-      }
-      findItem.quantityAccepted = parseInt(findItem.quantityAccepted) + 1;
+    const item = state.current.items.find((item: any)=> item.sku === payload);
+    if (item) {
+      item.quantityAccepted = item.quantityAccepted ? parseInt(item.quantityAccepted) + 1 : parseInt("0") + 1;
     } else {
       showToast(translate("Product not found"));
     }

--- a/src/store/modules/shipment/actions.ts
+++ b/src/store/modules/shipment/actions.ts
@@ -6,7 +6,6 @@ import * as types from './mutation-types'
 import { hasError, showToast } from '@/utils'
 import { translate } from '@hotwax/dxp-components'
 import emitter from '@/event-bus'
-import { Item } from "@ionic/core/dist/types/components/item/item";
 
 const actions: ActionTree<ShipmentState, RootState> = {
   async findShipment ({ commit, state }, payload) {

--- a/src/store/modules/shipment/actions.ts
+++ b/src/store/modules/shipment/actions.ts
@@ -34,9 +34,9 @@ const actions: ActionTree<ShipmentState, RootState> = {
   },
 
   async updateShipmentProductCount ({ commit, state }, payload) {
-    const item = state.current.items.find((item: any)=> item.sku === payload);
+    const item = state.current.items.find((item: any) => item.sku === payload);
     if (item) {
-      item.quantityAccepted = item.quantityAccepted ? parseInt(item.quantityAccepted) + 1 : parseInt("0") + 1;
+      item.quantityAccepted = item.quantityAccepted ? parseInt(item.quantityAccepted) + 1 : 1;
     } else {
       showToast(translate("Product not found"));
     }

--- a/src/store/modules/shipment/actions.ts
+++ b/src/store/modules/shipment/actions.ts
@@ -34,14 +34,17 @@ const actions: ActionTree<ShipmentState, RootState> = {
   },
 
   async updateShipmentProductCount ({ commit, state }, payload) {
-    await state.current.items.find((item: any) => {
-      if(item.sku === payload){
-        if (item.quantityAccepted === "") {
-          item.quantityAccepted = 0;
-        }
-        item.quantityAccepted = parseInt(item.quantityAccepted) + 1;
+    const findItem = state.current.items.find((item:any) => item.sku === payload);
+
+    if (findItem ) {
+      if (findItem.quantityAccepted === "") {
+        findItem.quantityAccepted = 0;
       }
-    });
+      findItem.quantityAccepted = parseInt(findItem.quantityAccepted) + 1;
+    } else {
+      showToast(translate("Product not found"));
+    }
+
     commit(types.SHIPMENT_CURRENT_UPDATED, state);
   },
   async setCurrent ({ commit }, payload) {

--- a/src/store/modules/shipment/actions.ts
+++ b/src/store/modules/shipment/actions.ts
@@ -36,6 +36,9 @@ const actions: ActionTree<ShipmentState, RootState> = {
   async updateShipmentProductCount ({ commit, state }, payload) {
     await state.current.items.find((item: any) => {
       if(item.sku === payload){
+        if (item.quantityAccepted === "") {
+          item.quantityAccepted = 0;
+        }
         item.quantityAccepted = parseInt(item.quantityAccepted) + 1;
       }
     });


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #308 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Resolved scanning failure caused by empty quantity fields by implementing automatic quantity update when scanning barcodes added toast message display for unavailable products to enhance user feedback.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)