### PR TITLE
Fixed: the issue of line after button by improving the html structure(#294)

### DIFF
--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -148,10 +148,10 @@
 
     <ion-footer>
       <ion-toolbar>
-        <ion-item slot="end">
-          <ion-button :disabled="!hasPermission(Actions.APP_SHIPMENT_UPDATE)" fill="outline" class="ion-margin-end" @click="closePO">{{ translate("Receive And Close") }}</ion-button>
-          <ion-button :disabled="!hasPermission(Actions.APP_SHIPMENT_UPDATE) || !isEligibileForCreatingShipment()" @click="savePODetails">{{ translate("Receive") }}</ion-button>
-        </ion-item>
+        <ion-buttons slot="end">
+          <ion-button fill="outline" size="small" color="primary" :disabled="!hasPermission(Actions.APP_SHIPMENT_UPDATE)" class="ion-margin-end" @click="closePO">{{ translate("Receive And Close") }}</ion-button>
+          <ion-button fill="solid" size="small" color="primary" :disabled="!hasPermission(Actions.APP_SHIPMENT_UPDATE) || !isEligibileForCreatingShipment()" @click="savePODetails">{{ translate("Receive") }}</ion-button>
+        </ion-buttons>
       </ion-toolbar>
     </ion-footer>
   </ion-page>


### PR DESCRIPTION
Removed: ion-item and replaced it with ion-buttons as when declaring ion-button inside toolbar we should use ion-buttons Added attributes on the ion-button to match the styling with the figma design

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #294

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

Before:

![image](https://github.com/hotwax/receiving/assets/41404838/662d445a-5dda-462c-9e5a-20ac1f136b35)

After:

![image](https://github.com/hotwax/receiving/assets/41404838/921a676a-19a1-4729-aeb9-f8996bef3a56)

**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)