### PR TITLE
Improved: code by removing toast message when the api for fetching po history fails(#302)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -195,7 +195,6 @@ const actions: ActionTree<OrderState, RootState> = {
     } catch(error){
       console.error(error)
       current.poHistory.items = [];
-      showToast(translate("Something went wrong"));
     }
     commit(types.ORDER_CURRENT_UPDATED, current);
     return resp;


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #302 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Removed the toast message when the api fails to fetch the history of purchase orders because if there is no orders in PO history then empty-state is defined so there is no need of  toast message. 

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)