### PR TITLE
Improved: added the shipped text to be shown with quantity ordered count in item card (#330)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -105,6 +105,7 @@
   "Shipments": "Shipments",
   "Shipments not found": "Shipments not found",
   "Shipped": "Shipped",
+  "shipped": "shipped",
   "Shop eCommerce": "Shop eCommerce",
   "Something went wrong": "Something went wrong",
   "Something went wrong while login. Please contact administrator": "Something went wrong while login. Please contact administrator.",

--- a/src/views/ShipmentDetails.vue
+++ b/src/views/ShipmentDetails.vue
@@ -75,7 +75,7 @@
 
             <ion-progress-bar :color="getRcvdToOrdrdFraction(item) > 1 ? 'danger' : 'primary'" :value="getRcvdToOrdrdFraction(item)" />
             
-            <p slot="end">{{ item.quantityOrdered }}</p>
+            <p slot="end">{{ item.quantityOrdered }} {{ translate("shipped") }}</p>
           </ion-item>
         </ion-card>
       </main>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #330

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Improved the item card in shipment details page to show static text "shipped" along with shipped item count.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)