### PR TITLE
Fixed: logout loader on login by only displaying the loader when user is authorized(#337)

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -108,11 +108,11 @@ const actions: ActionTree<UserState, RootState> = {
     // store the url on which we need to redirect the user after logout api completes in case of SSO enabled
     let redirectionUrl = ''
 
-    emitter.emit('presentLoader', { message: 'Logging out', backdropDismiss: false })
-
     // Calling the logout api to flag the user as logged out, only when user is authorised
     // if the user is already unauthorised then not calling the logout api as it returns 401 again that results in a loop, thus there is no need to call logout api if the user is unauthorised
     if(!payload?.isUserUnauthorised) {
+      emitter.emit('presentLoader', { message: 'Logging out', backdropDismiss: false })
+
       let resp;
 
       // wrapping the parsing logic in try catch as in some case the logout api makes redirection, and then we are unable to parse the resp and thus the logout process halts


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #337

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Moved loader displaying logic only when user is authorized

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

Before:

https://github.com/hotwax/receiving/assets/41404838/0c73f90d-5d5a-49e3-9d1b-cb52e1fb851a


After:

https://github.com/hotwax/receiving/assets/41404838/63eb77c9-fc9f-4000-af70-b01306244cc2


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)