### PR TITLE
Fixed: payload to pass shipmentItemSeqId for externally added item for a shipment(#357)

### DIFF
--- a/src/store/modules/shipment/actions.ts
+++ b/src/store/modules/shipment/actions.ts
@@ -100,6 +100,10 @@ const actions: ActionTree<ShipmentState, RootState> = {
         return Promise.reject("Missing locationSeqId on item")
       }
 
+      if(!item.itemSeqId) {
+        return Promise.reject("Missing shipmentItemSeqId on item")
+      }
+
       const params = {
         shipmentId: payload.shipmentId,
         facilityId: this.state.user.currentFacility.facilityId,
@@ -155,7 +159,14 @@ const actions: ActionTree<ShipmentState, RootState> = {
     const resp = await ShipmentService.addShipmentItem(params);
     if(resp.status == 200 && !hasError(resp)){
       dispatch('updateProductCount', { shipmentId: resp.data.shipmentId })
-      if (!payload.shipmentId) commit(types.SHIPMENT_CURRENT_PRODUCT_ADDED, product)
+      if (!payload.shipmentId) {
+        // When adding item to a shipment from details page, then adding the shipmentItemSeqId to item level, as we do not generate shipmentItemSeqId app side,
+        // when adding an item to shipment
+        commit(types.SHIPMENT_CURRENT_PRODUCT_ADDED, {
+          ...product,
+          itemSeqId: resp.data.shipmentItemSeqId
+        })
+      }
       return resp;
     } else {
       showToast(translate('Something went wrong'));


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #357

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added support to add the shipmentItemSeqId from the resp when adding a new item to the shipment, this will pass the shipmentItemSeqId to the externally added item on receiving.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)