### PR TITLE
Fixed: login issue in app when /api is not passed with oms complete url by updating the oms-api package and adding a check when accessing case url in the app(dxp/#272)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@hotwax/app-version-info": "^1.0.0",
         "@hotwax/apps-theme": "^1.1.0",
         "@hotwax/dxp-components": "^1.12.1",
-        "@hotwax/oms-api": "^1.10.0",
+        "@hotwax/oms-api": "^1.13.0",
         "@ionic/core": "6.7.5",
         "@ionic/vue": "6.7.5",
         "@ionic/vue-router": "6.7.5",
@@ -2877,9 +2877,9 @@
       }
     },
     "node_modules/@hotwax/oms-api": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@hotwax/oms-api/-/oms-api-1.11.0.tgz",
-      "integrity": "sha512-HQCXuADMVkQXAS9ClWFrTYNjSFP8wQuGMILEkLDh9R2YR1gNnJ4GezeZuxXQOjhxBg7zXxbdL3v5/q03P32O5g==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@hotwax/oms-api/-/oms-api-1.13.0.tgz",
+      "integrity": "sha512-D7bdS1XBfEu9fT23+mViC4FbyhFfg9GN95Epp/5V85Xcl8udxqOjHI9xcRMxANgrMjPNksshT1rm7F/TfEi/+g==",
       "dependencies": {
         "@types/node-json-transform": "^1.0.0",
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@hotwax/app-version-info": "^1.0.0",
     "@hotwax/apps-theme": "^1.1.0",
     "@hotwax/dxp-components": "^1.12.1",
-    "@hotwax/oms-api": "^1.10.0",
+    "@hotwax/oms-api": "^1.13.0",
     "@ionic/core": "6.7.5",
     "@ionic/vue": "6.7.5",
     "@ionic/vue-router": "6.7.5",

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -13,8 +13,7 @@ const login = async (username: string, password: string): Promise <any> => {
 }
 
 const checkPermission = async (payload: any): Promise <any>  => {
-  let baseURL = store.getters['user/getInstanceUrl'];
-  baseURL = baseURL && baseURL.startsWith('http') ? baseURL : `https://${baseURL}.hotwax.io/api/`;
+  const baseURL = store.getters['user/getBaseUrl'];
   return client({
     url: "checkPermission",
     method: "post",

--- a/src/store/modules/user/getters.ts
+++ b/src/store/modules/user/getters.ts
@@ -12,7 +12,7 @@ const getters: GetterTree <UserState, RootState> = {
     getBaseUrl (state) {
         let baseURL = process.env.VUE_APP_BASE_URL;
         if (!baseURL) baseURL = state.instanceUrl;
-        return baseURL.startsWith('http') ? baseURL : `https://${baseURL}.hotwax.io/api/`;
+        return baseURL.startsWith('http') ? baseURL.includes('/api') ? baseURL : `${baseURL}/api/` : `https://${baseURL}.hotwax.io/api/`;
     },
     getUserToken (state) {
         return state.token


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Related Issue https://github.com/hotwax/dxp-components/issues/272

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
As we have added support to check for `/api` in the url when the user enters the oms url in the format `https://.....`, we need to update the oms package in the apps to use this feature.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)