### PR TITLE
Improved: logic to update state on closing PO items status(#342)

### DIFF
--- a/src/components/ClosePurchaseOrderModal.vue
+++ b/src/components/ClosePurchaseOrderModal.vue
@@ -126,7 +126,6 @@ export default defineComponent({
     async updatePOItemStatus() {
       // Shipment can only be created if quantity is specified for atleast one PO item.
       // In some cases we don't need to create shipment instead directly need to close PO items.
-
       if(this.isEligibileForCreatingShipment) {
         const eligibleItemsForShipment = this.order.items.filter((item: any) => item.quantityAccepted > 0)
         await this.store.dispatch('order/createPurchaseShipment', { items: eligibleItemsForShipment, orderId: this.order.orderId })

--- a/src/components/ClosePurchaseOrderModal.vue
+++ b/src/components/ClosePurchaseOrderModal.vue
@@ -164,7 +164,7 @@ export default defineComponent({
         currentOrder.doclist.docs.map((item: any) => {
           if(completedItems.includes(item.orderItemSeqId)) {
             item.orderItemStatusId = "ITEM_COMPLETED"
-          } else if(item.orderItemStatusId !== "ITEM_COMPLETED" || item.orderItemStatusId !== "ITEM_REJECTED") {
+          } else if(item.orderItemStatusId !== "ITEM_COMPLETED" && item.orderItemStatusId !== "ITEM_REJECTED") {
             isPOCompleted = false
           }
         })

--- a/src/components/ClosePurchaseOrderModal.vue
+++ b/src/components/ClosePurchaseOrderModal.vue
@@ -94,7 +94,8 @@ export default defineComponent({
       getProduct: 'product/getProduct',
       getPOItemAccepted: 'order/getPOItemAccepted',
       order: 'order/getCurrent',
-      productIdentificationPref: 'user/getProductIdentificationPref'
+      productIdentificationPref: 'user/getProductIdentificationPref',
+      purchaseOrders: 'order/getPurchaseOrders'
     })
   },
   props: ['isEligibileForCreatingShipment'],
@@ -125,6 +126,7 @@ export default defineComponent({
     async updatePOItemStatus() {
       // Shipment can only be created if quantity is specified for atleast one PO item.
       // In some cases we don't need to create shipment instead directly need to close PO items.
+
       if(this.isEligibileForCreatingShipment) {
         const eligibleItemsForShipment = this.order.items.filter((item: any) => item.quantityAccepted > 0)
         await this.store.dispatch('order/createPurchaseShipment', { items: eligibleItemsForShipment, orderId: this.order.orderId })
@@ -137,10 +139,41 @@ export default defineComponent({
           orderItemSeqId: item.orderItemSeqId,
           statusId: "ITEM_COMPLETED"
         })
+        return item.orderItemSeqId
       }))
       const failedItemsCount = responses.filter((response) => response.status === 'rejected').length
       if(failedItemsCount){
         console.error('Failed to update the status of purchase order items.')
+      }
+
+      const completedItems = responses.filter((response) => response.status === 'fulfilled')?.map((response: any) => response.value)
+
+      if(!completedItems.length) return;
+
+      this.order.items.map((item: any) => {
+        if(completedItems.includes(item.orderItemSeqId)) {
+          item.orderItemStatusId = "ITEM_COMPLETED"
+        }
+      })
+      this.store.dispatch("order/updateCurrentOrder", this.order)
+
+      if(this.purchaseOrders.length) {
+        let purchaseOrders = JSON.parse(JSON.stringify(this.purchaseOrders))
+        const currentOrder = purchaseOrders.find((purchaseOrder: any) => purchaseOrder.groupValue === this.order.orderId)
+        let isPOCompleted = true;
+
+        currentOrder.doclist.docs.map((item: any) => {
+          if(completedItems.includes(item.orderItemSeqId)) {
+            item.orderItemStatusId = "ITEM_COMPLETED"
+          } else if(item.orderItemStatusId !== "ITEM_COMPLETED" || item.orderItemStatusId !== "ITEM_REJECTED") {
+            isPOCompleted = false
+          }
+        })
+
+        if(isPOCompleted) {
+          purchaseOrders = purchaseOrders.filter((purchaseOrder: any) => purchaseOrder.groupValue !== currentOrder.groupValue)
+        }
+        this.store.dispatch("order/updatePurchaseOrders", { purchaseOrders })
       }
     },
     isEligibleToClosePOItems() {

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -209,10 +209,19 @@ const actions: ActionTree<OrderState, RootState> = {
     }
     commit(types.ORDER_CURRENT_UPDATED, state.current)
   },
+  updateCurrentOrder({ state, commit }, payload) {
+    commit(types.ORDER_CURRENT_UPDATED, payload)
+  },
   clearPurchaseOrders({commit}){
     commit(types.ORDER_PRCHS_ORDRS_UPDATED, {
       list: [],
       total: 0
+    })
+  },
+  updatePurchaseOrders({commit, state}, payload){
+    commit(types.ORDER_PRCHS_ORDRS_UPDATED, {
+      list: payload.purchaseOrders,
+      total: payload.total ? payload.total : state.purchaseOrders.total
     })
   }
 }

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -209,7 +209,7 @@ const actions: ActionTree<OrderState, RootState> = {
     }
     commit(types.ORDER_CURRENT_UPDATED, state.current)
   },
-  updateCurrentOrder({ state, commit }, payload) {
+  updateCurrentOrder({ commit }, payload) {
     commit(types.ORDER_CURRENT_UPDATED, payload)
   },
   clearPurchaseOrders({commit}){


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #342

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Updating PO item status to "ITEM_COMPLETED" once it is successfully closed.
- Removing PO from the state once all the items of a PO is closed.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)