### PR TITLE
Improved: logic to clear the scanned SKU from the ion-input once successfully scanned and highlight scanned items (#367)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -44,6 +44,8 @@ const actions: ActionTree<OrderState, RootState> = {
     const item = state.current.items.find((item: any) => item.internalName === payload);
 
     if (item) {
+      if(item.orderItemStatusId === 'ITEM_COMPLETED') return { isCompleted: true }
+
       item.quantityAccepted = item.quantityAccepted ? parseInt(item.quantityAccepted) + 1 : 1;
       commit(types.ORDER_CURRENT_UPDATED, state.current )
       return { isProductFound: true }

--- a/src/store/modules/return/actions.ts
+++ b/src/store/modules/return/actions.ts
@@ -38,10 +38,10 @@ const actions: ActionTree<ReturnState, RootState> = {
     if (item) {
       item.quantityAccepted = item.quantityAccepted ? parseInt(item.quantityAccepted) + 1 : 1;
       commit(types.RETURN_CURRENT_UPDATED, state);
-      showToast(translate("Scanned successfully.", { itemName: payload }))
-    } else {
-      showToast(translate("Scanned item is not present within the shipment:", { itemName: payload }))
+      return { isProductFound: true }
     }
+
+    return { isProductFound: false }
   },
   async setCurrent ({ commit, state }, payload) {
     let resp;

--- a/src/store/modules/shipment/actions.ts
+++ b/src/store/modules/shipment/actions.ts
@@ -48,7 +48,7 @@ const actions: ActionTree<ShipmentState, RootState> = {
     if (item) {
       item.quantityAccepted = item.quantityAccepted ? parseInt(item.quantityAccepted) + 1 : 1;
       commit(types.SHIPMENT_CURRENT_UPDATED, state);
-      return { isProductFound: true, item }
+      return { isProductFound: true }
     }
 
     return { isProductFound: false }

--- a/src/store/modules/shipment/actions.ts
+++ b/src/store/modules/shipment/actions.ts
@@ -48,7 +48,7 @@ const actions: ActionTree<ShipmentState, RootState> = {
     if (item) {
       item.quantityAccepted = item.quantityAccepted ? parseInt(item.quantityAccepted) + 1 : 1;
       commit(types.SHIPMENT_CURRENT_UPDATED, state);
-      return { isProductFound: true }
+      return { isProductFound: true, item }
     }
 
     return { isProductFound: false }

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -31,7 +31,7 @@
 
         <div class="scanner">
           <ion-item>
-            <ion-input :label="translate('Scan items')" label-placement="fixed" autofocus :placeholder="translate('Scan barcodes to receive them')" v-model="queryString" @keyup.enter="updateProductCount($event)" />
+            <ion-input :label="translate('Scan items')" label-placement="fixed" autofocus :placeholder="translate('Scan barcodes to receive them')" v-model="queryString" @keyup.enter="updateProductCount()" />
           </ion-item>
           <ion-button expand="block" fill="outline" @click="scan">
             <ion-icon slot="start" :icon="cameraOutline" />
@@ -252,16 +252,12 @@ export default defineComponent({
       modal.onDidDismiss()
       .then((result) => {
         if (result.role) {
-          this.updateProductCount(null, result.role);
+          this.updateProductCount(result.role);
         }
       })
       return modal.present();
     },
-    async updateProductCount(event: any, payload: any) {
-      if(event && event.target.value) {
-        payload = event.target.value
-      }
-
+    async updateProductCount(payload: any) {
       if(this.queryString) payload = this.queryString
 
       if(!payload) {

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -48,7 +48,7 @@
           </ion-label>
         </ion-item>
 
-        <ion-card v-for="(item, index) in getPOItems('pending')" v-show="item.orderItemStatusId !== 'ITEM_COMPLETED' && item.orderItemStatusId !== 'ITEM_REJECTED'" :key="index">
+        <ion-card v-for="(item, index) in getPOItems('pending')" v-show="item.orderItemStatusId !== 'ITEM_COMPLETED' && item.orderItemStatusId !== 'ITEM_REJECTED'" :key="index" :class="getProduct(item.productId).sku === lastScannedId ? 'scanned-item' : '' " :id="getProduct(item.productId).sku">
           <div  class="product">
             <div class="product-info">
               <ion-item lines="none">
@@ -219,7 +219,8 @@ export default defineComponent({
   data() {
     return {
       queryString: '',
-      showCompletedItems: false
+      showCompletedItems: false,
+      lastScannedId: ''
     }
   },
   computed: {
@@ -265,8 +266,19 @@ export default defineComponent({
       }
       const result = await this.store.dispatch('order/updateProductCount', payload)
 
-      if (result.isProductFound) {
+      if(result.isCompleted) {
+        showToast(translate("Scanned item is already completed."))
+      } else if(result.isProductFound) {
         showToast(translate("Scanned successfully.", { itemName: payload }))
+        this.lastScannedId = payload
+        // Highlight specific element
+        const scannedElement = document.getElementById(payload);
+        scannedElement && (scannedElement.scrollIntoView());
+
+        // Scanned product should get un-highlighted after 3s for better experience hence adding setTimeOut
+        setTimeout(() => {
+          this.lastScannedId = ''
+        }, 3000)
       } else {
         showToast(translate("Scanned item is not present within the shipment:", { itemName: payload }), {
           buttons: [{
@@ -428,6 +440,10 @@ export default defineComponent({
 ion-thumbnail {
   cursor: pointer;
 } 
+
+.scanned-item {
+  outline: 2px solid var( --ion-color-medium-tint);
+}
 
 @media (min-width: 720px) {
   .doc-id {

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -443,6 +443,10 @@ ion-thumbnail {
 } 
 
 .scanned-item {
+  /*
+    Todo: used outline for highliting items for now, need to use border
+    Done this because currently ion-item inside ion-card is not inheriting highlighted background property.
+  */
   outline: 2px solid var( --ion-color-medium-tint);
 }
 

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -31,7 +31,7 @@
 
         <div class="scanner">
           <ion-item>
-            <ion-input :label="translate('Scan items')" label-placement="fixed" autofocus :placeholder="translate('Scan barcodes to receive them')" v-model="queryString" @keyup.enter="updateProductCount()" />
+            <ion-input :label="translate('Scan items')" label-placement="fixed" autofocus :placeholder="translate('Scan barcodes to receive them')" v-model="queryString" @keyup.enter="updateProductCount($event)" />
           </ion-item>
           <ion-button expand="block" fill="outline" @click="scan">
             <ion-icon slot="start" :icon="cameraOutline" />
@@ -252,12 +252,16 @@ export default defineComponent({
       modal.onDidDismiss()
       .then((result) => {
         if (result.role) {
-          this.updateProductCount(result.role);
+          this.updateProductCount(null, result.role);
         }
       })
       return modal.present();
     },
-    async updateProductCount(payload: any) {
+    async updateProductCount(event: any, payload: any) {
+      if(event && event.target.value) {
+        payload = event.target.value
+      }
+
       if(this.queryString) payload = this.queryString
 
       if(!payload) {
@@ -299,6 +303,7 @@ export default defineComponent({
           duration: 5000
         })
       }
+      this.queryString = ''
     },
     getPOItems(orderType: string) {
       if(orderType === 'completed'){

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -267,7 +267,7 @@ export default defineComponent({
       const result = await this.store.dispatch('order/updateProductCount', payload)
 
       if(result.isCompleted) {
-        showToast(translate("Scanned item is already completed."))
+        showToast(translate("Scanned item is not present within the shipment:", { itemName: payload }))
       } else if(result.isProductFound) {
         showToast(translate("Scanned successfully.", { itemName: payload }))
         this.lastScannedId = payload

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -48,7 +48,7 @@
           </ion-label>
         </ion-item>
 
-        <ion-card v-for="(item, index) in getPOItems('pending')" v-show="item.orderItemStatusId !== 'ITEM_COMPLETED' && item.orderItemStatusId !== 'ITEM_REJECTED'" :key="index" :class="getProduct(item.productId).sku === lastScannedId ? 'scanned-item' : '' " :id="getProduct(item.productId).sku">
+        <ion-card v-for="(item, index) in getPOItems('pending')" v-show="item.orderItemStatusId !== 'ITEM_COMPLETED' && item.orderItemStatusId !== 'ITEM_REJECTED'" :key="index" :class="item.internalName === lastScannedId ? 'scanned-item' : '' " :id="item.internalName">
           <div  class="product">
             <div class="product-info">
               <ion-item lines="none">

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -25,7 +25,7 @@
   
         <div class="scanner">
           <ion-item>
-            <ion-input :label="translate('Scan items')" autofocus :placeholder="translate('Scan barcodes to receive them')" v-model="queryString" @keyup.enter="updateProductCount()" />
+            <ion-input :label="translate('Scan items')" autofocus :placeholder="translate('Scan barcodes to receive them')" v-model="queryString" @keyup.enter="updateProductCount($event)" />
           </ion-item>
 
           <ion-button expand="block" fill="outline" @click="scanCode()">
@@ -245,7 +245,11 @@ export default defineComponent({
         }
       })
     },
-    async updateProductCount(payload?: any){
+    async updateProductCount(event: any, payload?: any){
+      if(event && event.target.value) {
+        payload = event.target.value
+      }
+
       if(this.queryString) payload = this.queryString
       // if not a valid status, skip updating the qunatity
       if(!this.isReturnReceivable(this.current.statusId)) return;
@@ -265,6 +269,7 @@ export default defineComponent({
       } else {
         showToast(translate("Scanned item is not present within the shipment:", { itemName: payload }))
       }
+      this.queryString = ''
     },
     async scanCode () {
       const modal = await modalController
@@ -274,7 +279,7 @@ export default defineComponent({
         modal.onDidDismiss()
         .then((result) => {
           if(result.role) {
-            this.updateProductCount(result.role);
+            this.updateProductCount(null, result.role);
           }
       });
       return modal.present();

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -33,7 +33,7 @@
           </ion-button>
         </div>
 
-        <ion-card v-for="item in current.items" :key="item.id">
+        <ion-card v-for="item in current.items" :key="item.id" :class="item.sku === lastScannedId ? 'scanned-item' : ''" :id="item.sku">
           <div class="product">
             <div class="product-info">
               <ion-item lines="none">
@@ -151,7 +151,8 @@ export default defineComponent({
         'Cancelled': 'danger',
         'Shipped': 'medium',
         'Created': 'medium'
-      } as any
+      } as any,
+      lastScannedId: ''
     }
   },
   async ionViewWillEnter() {
@@ -244,11 +245,26 @@ export default defineComponent({
         }
       })
     },
-    updateProductCount(payload?: any){
+    async updateProductCount(payload?: any){
       if(this.queryString) payload = this.queryString
       // if not a valid status, skip updating the qunatity
       if(!this.isReturnReceivable(this.current.statusId)) return;
-      this.store.dispatch('return/updateReturnProductCount', payload)
+
+      const result = await this.store.dispatch('return/updateReturnProductCount', payload)
+
+      if(result.isProductFound) {
+        showToast(translate("Scanned successfully.", { itemName: payload }))
+        this.lastScannedId = payload
+        const scannedElement = document.getElementById(payload);
+        scannedElement && (scannedElement.scrollIntoView());
+
+        // Scanned product should get un-highlighted after 3s for better experience hence adding setTimeOut
+        setTimeout(() => {
+          this.lastScannedId = ''
+        }, 3000)
+      } else {
+        showToast(translate("Scanned item is not present within the shipment:", { itemName: payload }))
+      }
     },
     async scanCode () {
       const modal = await modalController
@@ -286,6 +302,10 @@ export default defineComponent({
 <style scoped>
   ion-thumbnail {
     cursor: pointer;
+  }
+
+  .scanned-item {
+    outline: 2px solid var( --ion-color-medium-tint);
   }
 </style>
   

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -25,7 +25,7 @@
   
         <div class="scanner">
           <ion-item>
-            <ion-input :label="translate('Scan items')" autofocus :placeholder="translate('Scan barcodes to receive them')" v-model="queryString" @keyup.enter="updateProductCount($event)" />
+            <ion-input :label="translate('Scan items')" autofocus :placeholder="translate('Scan barcodes to receive them')" v-model="queryString" @keyup.enter="updateProductCount()" />
           </ion-item>
 
           <ion-button expand="block" fill="outline" @click="scanCode()">
@@ -245,11 +245,7 @@ export default defineComponent({
         }
       })
     },
-    async updateProductCount(event: any, payload?: any){
-      if(event && event.target.value) {
-        payload = event.target.value
-      }
-
+    async updateProductCount(payload?: any){
       if(this.queryString) payload = this.queryString
       // if not a valid status, skip updating the qunatity
       if(!this.isReturnReceivable(this.current.statusId)) return;
@@ -279,7 +275,7 @@ export default defineComponent({
         modal.onDidDismiss()
         .then((result) => {
           if(result.role) {
-            this.updateProductCount(null, result.role);
+            this.updateProductCount(result.role);
           }
       });
       return modal.present();

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -306,6 +306,10 @@ export default defineComponent({
   }
 
   .scanned-item {
+    /*
+      Todo: used outline for highliting items for now, need to use border
+      Done this because currently ion-item inside ion-card is not inheriting highlighted background property.
+    */
     outline: 2px solid var( --ion-color-medium-tint);
   }
 </style>

--- a/src/views/ShipmentDetails.vue
+++ b/src/views/ShipmentDetails.vue
@@ -31,7 +31,7 @@
           </ion-button>
         </div>
 
-        <ion-card v-for="item in current.items" :key="item.id">
+        <ion-card v-for="item in current.items" :key="item.id" :class="item.sku === lastScannedId ? 'scanned-item' : ''" :id="item.sku">
           <div class="product">
             <div class="product-info">
               <ion-item lines="none">
@@ -152,7 +152,8 @@ export default defineComponent({
   props: ["shipment"],
   data() {
     return {
-      queryString: ''
+      queryString: '',
+      lastScannedId: ''
     }
   },
   mounted() {
@@ -258,6 +259,14 @@ export default defineComponent({
 
       if (result.isProductFound) {
         showToast(translate("Scanned successfully.", { itemName: payload }))
+        this.lastScannedId = result.item.sku
+        const scannedElement = document.getElementById(result.item.sku);
+        scannedElement && (scannedElement.scrollIntoView());
+
+        // Scanned product should get un-highlighted after 3s for better experience hence adding setTimeOut
+        setTimeout(() => {
+          this.lastScannedId = ''
+        }, 3000)
       } else {
         showToast(translate("Scanned item is not present within the shipment:", { itemName: payload }), {
           buttons: [{
@@ -327,5 +336,9 @@ ion-thumbnail {
 
 .border-top {
   border-top: 1px solid #ccc;
+}
+
+.scanned-item {
+  outline: 2px solid var( --ion-color-medium-tint);
 }
 </style>

--- a/src/views/ShipmentDetails.vue
+++ b/src/views/ShipmentDetails.vue
@@ -257,10 +257,10 @@ export default defineComponent({
       }
       const result = await this.store.dispatch('shipment/updateShipmentProductCount', payload)
 
-      if (result.isProductFound) {
+      if(result.isProductFound) {
         showToast(translate("Scanned successfully.", { itemName: payload }))
-        this.lastScannedId = result.item.sku
-        const scannedElement = document.getElementById(result.item.sku);
+        this.lastScannedId = payload
+        const scannedElement = document.getElementById(payload);
         scannedElement && (scannedElement.scrollIntoView());
 
         // Scanned product should get un-highlighted after 3s for better experience hence adding setTimeOut

--- a/src/views/ShipmentDetails.vue
+++ b/src/views/ShipmentDetails.vue
@@ -23,7 +23,7 @@
 
         <div class="scanner" v-if="!isShipmentReceived()">
           <ion-item>
-            <ion-input :label="translate('Scan items')" autofocus :placeholder="translate('Scan barcodes to receive them')" v-model="queryString" @keyup.enter="updateProductCount()"></ion-input>
+            <ion-input :label="translate('Scan items')" autofocus :placeholder="translate('Scan barcodes to receive them')" v-model="queryString" @keyup.enter="updateProductCount($event)"></ion-input>
           </ion-item>
 
           <ion-button expand="block" fill="outline" @click="scanCode()">
@@ -243,7 +243,11 @@ export default defineComponent({
         }
       })
     },
-    async updateProductCount(payload: any){
+    async updateProductCount(event: any, payload: any){
+      if(event && event.target.value) {
+        payload = event.target.value
+      }
+
       if(this.queryString) payload = this.queryString
 
       if(!payload) {
@@ -274,6 +278,7 @@ export default defineComponent({
           duration: 5000
         })
       }
+      this.queryString = ''
     },
     async scanCode () {
       const modal = await modalController
@@ -283,7 +288,7 @@ export default defineComponent({
         modal.onDidDismiss()
         .then((result) => {
           if(result.role) {
-            this.updateProductCount(result.role);
+            this.updateProductCount(null, result.role);
           }
       });
       return modal.present();

--- a/src/views/ShipmentDetails.vue
+++ b/src/views/ShipmentDetails.vue
@@ -23,7 +23,7 @@
 
         <div class="scanner" v-if="!isShipmentReceived()">
           <ion-item>
-            <ion-input :label="translate('Scan items')" autofocus :placeholder="translate('Scan barcodes to receive them')" v-model="queryString" @keyup.enter="updateProductCount($event)"></ion-input>
+            <ion-input :label="translate('Scan items')" autofocus :placeholder="translate('Scan barcodes to receive them')" v-model="queryString" @keyup.enter="updateProductCount()"></ion-input>
           </ion-item>
 
           <ion-button expand="block" fill="outline" @click="scanCode()">
@@ -244,11 +244,7 @@ export default defineComponent({
         }
       })
     },
-    async updateProductCount(event: any, payload: any){
-      if(event && event.target.value) {
-        payload = event.target.value
-      }
-
+    async updateProductCount(payload: any){
       if(this.queryString) payload = this.queryString
 
       if(!payload) {
@@ -297,7 +293,7 @@ export default defineComponent({
         modal.onDidDismiss()
         .then((result) => {
           if(result.role) {
-            this.updateProductCount(null, result.role);
+            this.updateProductCount(result.role);
           }
       });
       return modal.present();

--- a/src/views/ShipmentDetails.vue
+++ b/src/views/ShipmentDetails.vue
@@ -335,6 +335,10 @@ ion-thumbnail {
 }
 
 .scanned-item {
+  /*
+    Todo: used outline for highliting items for now, need to use border
+    Done this because currently ion-item inside ion-card is not inheriting highlighted background property.
+  */
   outline: 2px solid var( --ion-color-medium-tint);
 }
 </style>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #367

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed scanning issue when using barcode reader as a keyboard input event.
- Clearing the scanned SKU from the ion-input after scanning it succesfully.
- Improved code to highlight the scanned item and scrollIntoView.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
[Screencast from 05-04-24 10:55:29 AM IST.webm](https://github.com/hotwax/receiving/assets/69574321/f34ec607-82d6-45eb-9c7a-596b65e4abe8)

[Screencast from 09-04-24 12:34:49 PM IST.webm](https://github.com/hotwax/receiving/assets/69574321/f9b7125d-beeb-48fe-b37d-69d07b458c41)



**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)