### PR TITLE
Fixed: Purchase Orders of Previous Facility Displayed After Changing Facility (#382)

### DIFF
--- a/src/views/PurchaseOrders.vue
+++ b/src/views/PurchaseOrders.vue
@@ -130,7 +130,7 @@ export default defineComponent({
       })
     },
   },
-  mounted () {
+  ionViewWillEnter () {
     this.getPurchaseOrders();
   },
   setup () {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#382

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Updated the hook used for fetching purchase order.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)