### PR TITLE
fixed: Blank header appears on return detail page if ShopifyOrderName and HC OrderID are not present (#399)

### DIFF
--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -11,7 +11,7 @@
       <main>
         <div class="doc-id">
           <ion-item lines="none">
-            <h1> {{ current.shopifyOrderName ? current.shopifyOrderName : current.hcOrderId ? current.hcOrderId : current.externalId ? current.externalId : 'Return' }}</h1>
+            <h1> {{ current.shopifyOrderName ? current.shopifyOrderName : current.hcOrderId ? current.hcOrderId : current.externalId ? current.externalId : translate("Return Details") }}</h1>
             <!-- TODO: Fetch Customer name -->
             <!-- <p>{{ translate("Customer: <customer name>")}}</p> -->
           </ion-item>

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -11,7 +11,7 @@
       <main>
         <div class="doc-id">
           <ion-item lines="none">
-            <h1>{{ current.shopifyOrderName ? current.shopifyOrderName : current.hcOrderId }}</h1>
+            <h1> {{ current.shopifyOrderName ? current.shopifyOrderName : current.hcOrderId ? current.hcOrderId : current.externalId ? current.externalId : 'Return' }}</h1>
             <!-- TODO: Fetch Customer name -->
             <!-- <p>{{ translate("Customer: <customer name>")}}</p> -->
           </ion-item>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#399 

### Short Description and Why It's Useful
When ShopifyOrderName and HC OrderID are missing, the header now displays alternative identifiers External ID. If no such identifiers is available, a placeholder message "Return" is shown ensuring the header is not blank.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/e8f2250b-4518-4733-b1b0-1fde1180bafd)



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)