### PR TITLE
Implemented: Show quantity on hand inventory during receiving(#416)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -63,6 +63,7 @@
   "No shipments have been received against this purchase order yet": "No shipments have been received against {lineBreak} this purchase order yet",
   "OMS": "OMS",
   "OMS instance": "OMS instance",
+  "on hand": "{ qoh } on hand",
   "Only allow received quantity to be incremented by scanning the barcode of products. If the identifier is not found, the scan will default to using the internal name.": "Only allow received quantity to be incremented by scanning the barcode of products. {space} If the identifier is not found, the scan will default to using the internal name.",
   "Open": "Open",
   "ordered": "ordered",

--- a/src/services/ProductService.ts
+++ b/src/services/ProductService.ts
@@ -1,4 +1,5 @@
-import { api } from '@/adapter';
+import { api, hasError } from '@/adapter';
+import store from '@/store';
 
 const fetchProducts = async (query: any): Promise <any> => {
   return api({
@@ -9,6 +10,31 @@ const fetchProducts = async (query: any): Promise <any> => {
   })
 }
 
+const getInventoryAvailableByFacility = async (productId: any): Promise<any> => {
+  let inventoryAvailableByFacility = {}
+  const payload = {
+    productId: productId,
+    facilityId: store.getters['user/getCurrentFacility']?.facilityId
+  }
+
+  try {
+    const resp: any = await api({
+      url: "service/getInventoryAvailableByFacility",
+      method: "post",
+      data: payload
+    })
+    if (!hasError(resp)) {
+      inventoryAvailableByFacility = resp?.data.quantityOnHandTotal;
+    } else {
+      throw resp.data;
+    }
+  } catch (err) {
+    console.error(err)
+  } 
+  return inventoryAvailableByFacility
+}
+
 export const ProductService = {
-  fetchProducts
+  fetchProducts,
+  getInventoryAvailableByFacility
 }

--- a/src/services/ProductService.ts
+++ b/src/services/ProductService.ts
@@ -11,7 +11,7 @@ const fetchProducts = async (query: any): Promise <any> => {
 }
 
 const getInventoryAvailableByFacility = async (productId: any): Promise<any> => {
-  let inventoryAvailableByFacility = {}
+  let productQoh = ''
   const payload = {
     productId: productId,
     facilityId: store.getters['user/getCurrentFacility']?.facilityId
@@ -24,14 +24,14 @@ const getInventoryAvailableByFacility = async (productId: any): Promise<any> => 
       data: payload
     })
     if (!hasError(resp)) {
-      inventoryAvailableByFacility = resp?.data.quantityOnHandTotal;
+      productQoh = resp?.data.quantityOnHandTotal;
     } else {
       throw resp.data;
     }
   } catch (err) {
     console.error(err)
   } 
-  return inventoryAvailableByFacility
+  return productQoh;
 }
 
 export const ProductService = {

--- a/src/services/ShipmentService.ts
+++ b/src/services/ShipmentService.ts
@@ -113,14 +113,6 @@ const fetchShipmentAttributes = async (shipmentIds: Array<string>): Promise<any>
   return shipmentAttributes;
 }
 
-const getInventoryAvailableByFacility = async (query: any): Promise <any> => {
-  return api({
-    url: "service/getInventoryAvailableByFacility",
-    method: "post",
-    data: query
-  });
-}
-
 export const ShipmentService = {
   fetchShipments,
   fetchShipmentAttributes,
@@ -129,5 +121,4 @@ export const ShipmentService = {
   receiveShipmentItem,
   receiveShipment,
   addShipmentItem,
-  getInventoryAvailableByFacility
 }

--- a/src/services/ShipmentService.ts
+++ b/src/services/ShipmentService.ts
@@ -113,6 +113,7 @@ const fetchShipmentAttributes = async (shipmentIds: Array<string>): Promise<any>
   return shipmentAttributes;
 }
 
+
 export const ShipmentService = {
   fetchShipments,
   fetchShipmentAttributes,
@@ -120,5 +121,5 @@ export const ShipmentService = {
   getShipmentDetail,
   receiveShipmentItem,
   receiveShipment,
-  addShipmentItem,
+  addShipmentItem
 }

--- a/src/services/ShipmentService.ts
+++ b/src/services/ShipmentService.ts
@@ -113,6 +113,13 @@ const fetchShipmentAttributes = async (shipmentIds: Array<string>): Promise<any>
   return shipmentAttributes;
 }
 
+const getInventoryAvailableByFacility = async (query: any): Promise <any> => {
+  return api({
+    url: "service/getInventoryAvailableByFacility",
+    method: "post",
+    data: query
+  });
+}
 
 export const ShipmentService = {
   fetchShipments,
@@ -121,5 +128,6 @@ export const ShipmentService = {
   getShipmentDetail,
   receiveShipmentItem,
   receiveShipment,
-  addShipmentItem
+  addShipmentItem,
+  getInventoryAvailableByFacility
 }

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -34,7 +34,7 @@
         </div>
 
         <ion-card v-for="item in current.items" :key="item.id" :class="item.sku === lastScannedId ? 'scanned-item' : ''" :id="item.sku">
-          <div class="product">
+          <div class="product" :data-product-id="item.productId">
             <div class="product-info">
               <ion-item lines="none">
                 <ion-thumbnail slot="start" @click="openImage(getProduct(item.productId).mainImageUrl, getProduct(item.productId).productName)">
@@ -48,9 +48,12 @@
             </div>
 
             <div class="location">
-              <ion-chip outline :disabled="true">
-                <ion-icon :icon="locationOutline" />
-                <ion-label>{{ current.locationSeqId }}</ion-label>
+              <ion-button v-if="!(productQoh[item.productId] >= 0)" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
+                <ion-icon color="medium" slot="icon-only" :icon="cubeOutline" />
+              </ion-button>
+              <ion-chip v-else outline>
+                {{ translate("on hand", { qoh: productQoh[item.productId] }) }}
+                <ion-icon color="medium" :icon="cubeOutline"/>
               </ion-chip>
             </div>
 
@@ -107,7 +110,7 @@ import {
   alertController,
 } from '@ionic/vue';
 import { defineComponent, computed } from 'vue';
-import { checkmarkDone, barcodeOutline, locationOutline } from 'ionicons/icons';
+import { checkmarkDone, cubeOutline, barcodeOutline, locationOutline } from 'ionicons/icons';
 import { mapGetters, useStore } from "vuex";
 import AddProductModal from '@/views/AddProductModal.vue'
 import { DxpShopifyImg, translate, getProductIdentificationValue, useProductIdentificationStore } from '@hotwax/dxp-components';
@@ -117,6 +120,7 @@ import ImageModal from '@/components/ImageModal.vue';
 import { hasError } from '@/utils';
 import { showToast } from '@/utils'
 import { Actions, hasPermission } from '@/authorization'
+import { ProductService } from '@/services/ProductService';
 
 export default defineComponent({
   name: "ReturnDetails",
@@ -152,11 +156,13 @@ export default defineComponent({
         'Shipped': 'medium',
         'Created': 'medium'
       } as any,
-      lastScannedId: ''
+      lastScannedId: '',
+      productQoh: {} as any
     }
   },
   async ionViewWillEnter() {
     const current = await this.store.dispatch('return/setCurrent', { shipmentId: this.$route.params.id })
+    this.observeProductVisibility();
   },
   computed: {
     ...mapGetters({
@@ -201,7 +207,31 @@ export default defineComponent({
       }
       await this.store.dispatch("product/fetchProducts", payload);
     },
-    
+    observeProductVisibility() {
+      const observer = new IntersectionObserver((entries: any) => {
+        entries.forEach((entry: any) => {
+          if (entry.isIntersecting) {
+            const productId = entry.target.getAttribute('data-product-id');
+            if (productId && !(this.productQoh[productId] >= 0)) {
+              this.fetchQuantityOnHand(productId);
+            }
+          }
+        });
+      }, {
+        root: null,
+        threshold: 0.4
+      });
+
+      const products = document.querySelectorAll('.product');
+      if (products) {
+        products.forEach((product: any) => {
+          observer.observe(product);
+        });
+      }
+    },
+    async fetchQuantityOnHand(productId: any) {
+      this.productQoh[productId] = await ProductService.getInventoryAvailableByFacility(productId);  
+    },
     async completeShipment() {
       const alert = await alertController.create({
         header: translate("Receive Shipment"),
@@ -305,6 +335,7 @@ export default defineComponent({
       Actions,
       barcodeOutline,
       checkmarkDone,
+      cubeOutline,
       hasPermission,
       locationOutline,
       store,

--- a/src/views/ShipmentDetails.vue
+++ b/src/views/ShipmentDetails.vue
@@ -48,7 +48,7 @@
             </div>
 
             <div class="location">
-              <ion-button v-if="!productQoh[item.productId]" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
+              <ion-button v-if="!(productQoh[item.productId] >= 0)" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
                 <ion-icon color="medium" slot="icon-only" :icon="cubeOutline" />
               </ion-button>
               <ion-chip v-else outline>

--- a/src/views/ShipmentDetails.vue
+++ b/src/views/ShipmentDetails.vue
@@ -124,9 +124,9 @@ import { DxpShopifyImg, translate, getProductIdentificationValue, useProductIden
 import { useRouter } from 'vue-router';
 import Scanner from "@/components/Scanner.vue";
 import ImageModal from '@/components/ImageModal.vue';
-import { hasError, showToast } from '@/utils'
+import { showToast } from '@/utils'
 import { Actions, hasPermission } from '@/authorization'
-import { ShipmentService } from '@/services/ShipmentService';
+import { ProductService } from '@/services/ProductService';
 
 export default defineComponent({
   name: "ShipmentDetails",
@@ -222,21 +222,7 @@ export default defineComponent({
       }
     },
     async fetchQuantityOnHand(productId: any) {
-      try {
-        const payload = {
-          productId: productId,
-          facilityId: this.currentFacility.facilityId
-        }
-
-        const resp: any = await ShipmentService.getInventoryAvailableByFacility(payload);
-        if (!hasError(resp)) {
-          this.productQoh[productId] = resp.data.quantityOnHandTotal;
-        } else {
-          throw resp.data;
-        }
-      } catch (err) {
-        console.error(err)
-      } 
+      this.productQoh[productId] = await ProductService.getInventoryAvailableByFacility(productId);  
     },
     async fetchProducts(vSize: any, vIndex: any) {
       const viewSize = vSize ? vSize : process.env.VUE_APP_VIEW_SIZE;

--- a/src/views/ShipmentDetails.vue
+++ b/src/views/ShipmentDetails.vue
@@ -48,10 +48,12 @@
             </div>
 
             <div class="location">
-              <LocationPopover v-if="!isShipmentReceived() && item.quantityReceived === 0" :item="item" type="shipment" :facilityId="currentFacility.facilityId" />
-              <ion-chip :disabled="true" outline v-else>
-                <ion-icon :icon="locationOutline"/>
-                <ion-label>{{ item.locationSeqId }}</ion-label>
+              <ion-button v-if="!productQoh[item.productId]" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
+                <ion-icon color="medium" slot="icon-only" :icon="cubeOutline" />
+              </ion-button>
+              <ion-chip v-else outline>
+                {{ translate("on hand", { qoh: productQoh[item.productId] }) }}
+                <ion-icon color="medium" :icon="cubeOutline"/>
               </ion-chip>
             </div>
 
@@ -115,16 +117,16 @@ import {
   alertController,
 } from '@ionic/vue';
 import { defineComponent, computed } from 'vue';
-import { add, checkmarkDone, checkmarkDoneCircleOutline, cameraOutline, locationOutline, warningOutline } from 'ionicons/icons';
+import { add, checkmarkDone, checkmarkDoneCircleOutline, cameraOutline, cubeOutline, locationOutline, warningOutline } from 'ionicons/icons';
 import { mapGetters, useStore } from "vuex";
 import AddProductModal from '@/views/AddProductModal.vue'
 import { DxpShopifyImg, translate, getProductIdentificationValue, useProductIdentificationStore } from '@hotwax/dxp-components';
 import { useRouter } from 'vue-router';
 import Scanner from "@/components/Scanner.vue";
-import LocationPopover from '@/components/LocationPopover.vue'
 import ImageModal from '@/components/ImageModal.vue';
 import { hasError, showToast } from '@/utils'
 import { Actions, hasPermission } from '@/authorization'
+import { ShipmentService } from '@/services/ShipmentService';
 
 export default defineComponent({
   name: "ShipmentDetails",
@@ -149,13 +151,13 @@ export default defineComponent({
     IonToolbar,
     DxpShopifyImg,
     IonChip,
-    LocationPopover
   },
   props: ["shipment"],
   data() {
     return {
       queryString: '',
-      lastScannedId: ''
+      lastScannedId: '',
+      productQoh: {} as any
     }
   },
   mounted() {
@@ -195,6 +197,24 @@ export default defineComponent({
           this.store.dispatch('product/clearSearchedProducts')
         })
       return modal.present();
+    },
+    async fetchQuantityOnHand(productId: any) {
+      try {
+        const payload = {
+          productId: productId,
+          facilityId: this.currentFacility.facilityId
+        }
+
+        const resp: any = await ShipmentService.getInventoryAvailableByFacility(payload);
+        if (!hasError(resp)) {
+          this.productQoh[productId] = resp.data.quantityOnHandTotal;
+        } else {
+          throw resp.data;
+        }
+      } catch (err) {
+        console.error(err)
+        showToast(translate('No data available!'))
+      } 
     },
     async fetchProducts(vSize: any, vIndex: any) {
       const viewSize = vSize ? vSize : process.env.VUE_APP_VIEW_SIZE;
@@ -334,6 +354,7 @@ export default defineComponent({
       cameraOutline,
       checkmarkDone,
       checkmarkDoneCircleOutline,
+      cubeOutline,
       hasPermission,
       locationOutline,
       store,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#416 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added support to display the quantity on hand `(QOH)` of a product at the currently selected facility.
- Added a cube icon that, when clicked, shows an ion-chip displaying the QOH for that line item.
- Fetched the information from the `getInventoryAvailableByFacility` service.
### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

![image](https://github.com/user-attachments/assets/7bbef7d9-6f2e-4319-9ca7-3f2ab0690c18)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)