### PR TITLE
Improved: Inventory will update after shipment & return(#429)

### DIFF
--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -329,6 +329,9 @@ export default defineComponent({
       this.queryString = ''
     }
   }, 
+  ionViewDidLeave() {
+    this.productQoh = {};
+  },
   setup() {
     const store = useStore(); 
     const router = useRouter();

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -164,6 +164,9 @@ export default defineComponent({
     const current = await this.store.dispatch('return/setCurrent', { shipmentId: this.$route.params.id })
     this.observeProductVisibility();
   },
+  ionViewDidLeave() {
+    this.productQoh = {};
+  },
   computed: {
     ...mapGetters({
       current: 'return/getCurrent',
@@ -329,9 +332,6 @@ export default defineComponent({
       this.queryString = ''
     }
   }, 
-  ionViewDidLeave() {
-    this.productQoh = {};
-  },
   setup() {
     const store = useStore(); 
     const router = useRouter();

--- a/src/views/ShipmentDetails.vue
+++ b/src/views/ShipmentDetails.vue
@@ -350,6 +350,9 @@ export default defineComponent({
       this.queryString = ''
     }
   }, 
+  ionViewDidLeave() {
+    this.productQoh = {};
+  },
   setup() {
     const store = useStore(); 
     const router = useRouter();

--- a/src/views/ShipmentDetails.vue
+++ b/src/views/ShipmentDetails.vue
@@ -164,6 +164,9 @@ export default defineComponent({
     await this.store.dispatch('shipment/setCurrent', { shipmentId: this.$route.params.id })
     this.observeProductVisibility();
   },
+  ionViewDidLeave() {
+    this.productQoh = {};
+  },
   computed: {
     ...mapGetters({
       current: 'shipment/getCurrent',
@@ -350,9 +353,6 @@ export default defineComponent({
       this.queryString = ''
     }
   }, 
-  ionViewDidLeave() {
-    this.productQoh = {};
-  },
   setup() {
     const store = useStore(); 
     const router = useRouter();


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#429 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- After a shipment or return, the user can see the updated inventory in the "Completed" tab.  
- Clearing the `productQoh` variable in `ionViewDidLeave`, which holds the product quantity on hand (QoH), ensures that when the user switches tabs, the updated QoH is fetched.  

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)