### PR TITLE
Fixed: Added checks to prevent updating Force Scanning and Bar Identifiers settings when no product store(#436)

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -156,20 +156,6 @@ const actions: ActionTree<UserState, RootState> = {
   },
 
   /**
-   *  update current eComStore information
-  */
-  async setEComStore({ commit, dispatch }, payload) {
-    commit(types.USER_CURRENT_ECOM_STORE_UPDATED, payload.eComStore);
-    await UserService.setUserPreference({
-      'userPrefTypeId': 'SELECTED_BRAND',
-      'userPrefValue': payload.eComStore.productStoreId
-    });
-    await useProductIdentificationStore().getIdentificationPref(payload.eComStore.productStoreId);
-    this.dispatch('util/getForceScanSetting', payload.ecomStore.productStoreId)
-    this.dispatch('util/getBarcodeIdentificationPref', payload.ecomStore.productStoreId)
-  },
-
-  /**
    * update current facility information
    */
   async setFacility ({ commit, dispatch }, facilityId) {
@@ -180,6 +166,8 @@ const actions: ActionTree<UserState, RootState> = {
     // Initialize or update eComStore based on productStoreId changes
     if(!Object.keys(eComStore).length) {
       useUserStore().currentEComStore = {}
+      this.dispatch('util/getForceScanSetting', '')
+      this.dispatch('util/getBarcodeIdentificationPref', '')
     } else {
       if(previousEComStore.productStoreId !== eComStore.productStoreId) {
         await useUserStore().setEComStorePreference(eComStore);

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -167,8 +167,7 @@ const actions: ActionTree<UserState, RootState> = {
     if(!Object.keys(eComStore).length) {
       useUserStore().currentEComStore = {}
       commit(types.USER_CURRENT_ECOM_STORE_UPDATED, '');
-      this.dispatch('util/getForceScanSetting', '')
-      this.dispatch('util/getBarcodeIdentificationPref', '')
+      await dispatch('updateSettingsToDefault')
     } else if(previousEComStore.productStoreId !== eComStore.productStoreId) {
       await useUserStore().setEComStorePreference(eComStore);
       commit(types.USER_CURRENT_ECOM_STORE_UPDATED, eComStore);
@@ -177,6 +176,11 @@ const actions: ActionTree<UserState, RootState> = {
     }
   },
   
+  async updateSettingsToDefault() {
+    this.dispatch('util/updateForceScanStatus', false)
+    this.dispatch('util/updateBarcodeIdentificationPref', "internalName")
+  },
+
   /**
    * Update user timeZone
    */

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -177,12 +177,16 @@ const actions: ActionTree<UserState, RootState> = {
     const previousEComStore = await useUserStore().getCurrentEComStore as any
     const eComStore = await UserService.getEComStores(token, facilityId);
     await dispatch('getFacilityLocations', facilityId)
-
-    if(previousEComStore.productStoreId !== eComStore.productStoreId) {
-      await useUserStore().setEComStorePreference(eComStore);
-      commit(types.USER_CURRENT_ECOM_STORE_UPDATED, eComStore);
-      eComStore?.productStoreId ? this.dispatch('util/getForceScanSetting', eComStore.productStoreId) : this.dispatch('util/updateForceScanStatus', false)
-      eComStore?.productStoreId ? this.dispatch('util/getBarcodeIdentificationPref', eComStore.productStoreId) : this.dispatch('util/updateBarcodeIdentificationPref', "internalName")
+    // Initialize or update eComStore based on productStoreId changes
+    if(!Object.keys(eComStore).length) {
+      useUserStore().currentEComStore = {}
+    } else {
+      if(previousEComStore.productStoreId !== eComStore.productStoreId) {
+        await useUserStore().setEComStorePreference(eComStore);
+        commit(types.USER_CURRENT_ECOM_STORE_UPDATED, eComStore);
+        this.dispatch('util/getForceScanSetting', eComStore.productStoreId)
+        this.dispatch('util/getBarcodeIdentificationPref', eComStore.productStoreId)
+      }
     }
   },
   

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -180,7 +180,6 @@ const actions: ActionTree<UserState, RootState> = {
     this.dispatch('util/updateForceScanStatus', false)
     this.dispatch('util/updateBarcodeIdentificationPref', "internalName")
   },
-
   /**
    * Update user timeZone
    */

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -166,15 +166,14 @@ const actions: ActionTree<UserState, RootState> = {
     // Initialize or update eComStore based on productStoreId changes
     if(!Object.keys(eComStore).length) {
       useUserStore().currentEComStore = {}
+      commit(types.USER_CURRENT_ECOM_STORE_UPDATED, '');
       this.dispatch('util/getForceScanSetting', '')
       this.dispatch('util/getBarcodeIdentificationPref', '')
-    } else {
-      if(previousEComStore.productStoreId !== eComStore.productStoreId) {
-        await useUserStore().setEComStorePreference(eComStore);
-        commit(types.USER_CURRENT_ECOM_STORE_UPDATED, eComStore);
-        this.dispatch('util/getForceScanSetting', eComStore.productStoreId)
-        this.dispatch('util/getBarcodeIdentificationPref', eComStore.productStoreId)
-      }
+    } else if(previousEComStore.productStoreId !== eComStore.productStoreId) {
+      await useUserStore().setEComStorePreference(eComStore);
+      commit(types.USER_CURRENT_ECOM_STORE_UPDATED, eComStore);
+      this.dispatch('util/getForceScanSetting', eComStore.productStoreId)
+      this.dispatch('util/getBarcodeIdentificationPref', eComStore.productStoreId)
     }
   },
   

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -49,10 +49,6 @@ const actions: ActionTree<UtilState, RootState> = {
   },
 
   async getForceScanSetting({ commit, dispatch }, eComStoreId) {
-    if(!eComStoreId) {
-      commit(types.UTIL_FORCE_SCAN_STATUS_UPDATED, "false")
-      return;
-    }
 
     const payload = {
       "inputFields": {
@@ -175,10 +171,6 @@ const actions: ActionTree<UtilState, RootState> = {
   },
 
   async getBarcodeIdentificationPref({ commit, dispatch }, eComStoreId) {
-    if(!eComStoreId) {
-      commit(types.UTIL_BARCODE_IDENTIFICATION_PREF_UPDATED, "internalName")
-      return;
-    }
 
     const payload = {
       "inputFields": {

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -49,6 +49,11 @@ const actions: ActionTree<UtilState, RootState> = {
   },
 
   async getForceScanSetting({ commit, dispatch }, eComStoreId) {
+    if(!eComStoreId) {
+      commit(types.UTIL_FORCE_SCAN_STATUS_UPDATED, "false")
+      return;
+    }
+
     const payload = {
       "inputFields": {
         "productStoreId": eComStoreId,
@@ -170,6 +175,11 @@ const actions: ActionTree<UtilState, RootState> = {
   },
 
   async getBarcodeIdentificationPref({ commit, dispatch }, eComStoreId) {
+    if(!eComStoreId) {
+      commit(types.UTIL_BARCODE_IDENTIFICATION_PREF_UPDATED, "internalName")
+      return;
+    }
+
     const payload = {
       "inputFields": {
         "productStoreId": eComStoreId,

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -49,7 +49,6 @@ const actions: ActionTree<UtilState, RootState> = {
   },
 
   async getForceScanSetting({ commit, dispatch }, eComStoreId) {
-
     const payload = {
       "inputFields": {
         "productStoreId": eComStoreId,
@@ -171,7 +170,6 @@ const actions: ActionTree<UtilState, RootState> = {
   },
 
   async getBarcodeIdentificationPref({ commit, dispatch }, eComStoreId) {
-
     const payload = {
       "inputFields": {
         "productStoreId": eComStoreId,


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#436 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added a check during login: If the selected facility does not have an associated product store, `Force Scanning` and `Bar Code Identifier` will be set to their default values.  
- Similarly, after updating the facility, if no product store is found, the default settings will be applied.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)