### PR TITLE
 Fixed: Incorrect SKU search retains previous results instead of displaying an empty state in the add product modal.(#395)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -59,6 +59,7 @@
   "Make sure you have entered all the inventory you received. You cannot edit this information after proceeding.": "Make sure you have entered all the inventory you received. { space } You cannot edit this information after proceeding.",
   "No facilities found": "No facilities found",
   "No more shipments found": "No more shipments found",
+  "No product found":"No product found",
   "None": "None",
   "No results found": "No results found",
   "No time zone found": "No time zone found",

--- a/src/views/AddProductToPOModal.vue
+++ b/src/views/AddProductToPOModal.vue
@@ -119,9 +119,7 @@ export default defineComponent({
       }
       await this.store.dispatch("product/findProduct", payload);
     },
-    async handleSearch(){
-      console.log(this.queryString);
-      
+    async handleSearch(){    
       if(!this.queryString){
         showToast(translate("Enter product sku to search"))
         this.isSearching = false

--- a/src/views/AddProductToPOModal.vue
+++ b/src/views/AddProductToPOModal.vue
@@ -10,7 +10,7 @@
     </ion-toolbar>
   </ion-header>
   <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()">
-    <ion-searchbar @ionFocus="selectSearchBarText($event)" v-model="queryString" :placeholder="translate('Search SKU or product name')" v-on:keyup.enter="queryString = $event.target.value; getProducts()" />
+    <ion-searchbar @ionFocus="selectSearchBarText($event)" v-model="queryString" :placeholder="translate('Search SKU or product name')" @keyup.enter="handleSearch" @IonInput='handleInput'/>
     <template v-if="products.length">
       <ion-list v-for="product in products" :key="product.productId">
         <ion-item lines="none">
@@ -31,6 +31,9 @@
         <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')" />
       </ion-infinite-scroll>
     </template>
+    <div v-else-if="queryString && isSearching && !products.length" class="empty-state">
+      <p>{{ translate("No product found") }}</p>
+    </div>
     <div v-else class="empty-state">
       <img src="../assets/images/empty-state-add-product-modal.png" alt="empty-state" />
       <p>{{ translate("Enter a SKU, or product name to search a product") }}</p>
@@ -85,7 +88,8 @@ export default defineComponent({
   data() {
     return {
       queryString: this.selectedSKU ? this.selectedSKU : '',
-      isScrollingEnabled: false
+      isScrollingEnabled: false,
+      isSearching: false
     }
   },
   props: ["selectedSKU"],
@@ -113,11 +117,24 @@ export default defineComponent({
         viewIndex,
         queryString: this.queryString
       }
-      if (this.queryString) {
-        await this.store.dispatch("product/findProduct", payload);
-      }
-      else {
+      await this.store.dispatch("product/findProduct", payload);
+    },
+    async handleSearch(){
+      console.log(this.queryString);
+      
+      if(!this.queryString){
         showToast(translate("Enter product sku to search"))
+        this.isSearching = false
+        this.store.dispatch("product/clearSearchedProducts")
+        return
+      }
+      await this.getProducts()
+      this.isSearching = true
+    },
+    async handleInput(){
+      if(!this.queryString){
+        this.isSearching = false
+        this.store.dispatch("product/clearSearchedProducts")
       }
     },
     enableScrolling() {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#395 
#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When an incorrect SKU is entered, the app clears the previous results and display an empty state or a message "No products found."



### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)