### PR TITLE
Improved: The tab and segment navigation when switching from the details page.(#428)

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -25,8 +25,13 @@ declare module 'vue-router' {
 }
 
 const setSegmentQuery = async (to: any, from: any, next: any) => {
-  const segmentResetRoutes = ['/shipments', '/purchase-orders', '/returns'];
-  if (segmentResetRoutes.some(route => from.path.startsWith(route))) {
+  const segmentResetRoutes = ['/shipments', '/purchase-orders', '/returns', '/settings']
+
+  //Extract the first word from from.path to determine whether the navigation 
+  // is returning from a child route of the current menu or a different menu's child route.
+  const fromChildRoute = from.path.split('/')[1]?.split('-')[0] || ''
+
+  if (segmentResetRoutes.some(route => from.path.startsWith(route)) || !to.path.includes(`/${fromChildRoute}`)) {
     to.query.segment = 'open';
   }  
   next();

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -24,6 +24,14 @@ declare module 'vue-router' {
   }
 }
 
+const setSegmentQuery = async (to: any, from: any, next: any) => {
+  const completedRoutes = ['/shipments', '/purchase-orders', '/returns'];
+  if (completedRoutes.some(route => from.path.startsWith(route))) {
+    to.query.segment = 'open';
+  }  
+  next();
+}
+
 const authGuard = async (to: any, from: any, next: any) => {
   const authStore = useAuthStore()
   if (!authStore.isAuthenticated || !store.getters['user/isAuthenticated']) {
@@ -53,7 +61,7 @@ const routes: Array<RouteRecordRaw> = [
     path: '/shipments',
     name: 'Shipments',
     component: Shipments,
-    beforeEnter: authGuard,
+    beforeEnter: [authGuard, setSegmentQuery],
     meta: {
       permissionId: "APP_SHIPMENTS_VIEW"
     }
@@ -83,7 +91,7 @@ const routes: Array<RouteRecordRaw> = [
     path: '/purchase-orders',
     name: 'PurchaseOrders',
     component: PurchaseOrders,
-    beforeEnter: authGuard,
+    beforeEnter: [authGuard, setSegmentQuery],
     meta: {
       permissionId: "APP_PURCHASEORDERS_VIEW"
     }
@@ -106,7 +114,7 @@ const routes: Array<RouteRecordRaw> = [
     path: '/returns',
     name: 'Returns',
     component: Returns,
-    beforeEnter: authGuard,
+    beforeEnter: [authGuard, setSegmentQuery],
     meta: {
       permissionId: "APP_RETURNS_VIEW"
     }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -25,8 +25,8 @@ declare module 'vue-router' {
 }
 
 const setSegmentQuery = async (to: any, from: any, next: any) => {
-  const completedRoutes = ['/shipments', '/purchase-orders', '/returns'];
-  if (completedRoutes.some(route => from.path.startsWith(route))) {
+  const segmentResetRoutes = ['/shipments', '/purchase-orders', '/returns'];
+  if (segmentResetRoutes.some(route => from.path.startsWith(route))) {
     to.query.segment = 'open';
   }  
   next();

--- a/src/views/PurchaseOrders.vue
+++ b/src/views/PurchaseOrders.vue
@@ -150,6 +150,9 @@ export default defineComponent({
     }
   },
   ionViewWillEnter () {
+    if (this.$route.query.segment){
+      this.selectedSegment = this.$route.query.segment.toString();
+    }    
     this.getPurchaseOrders();
   },
   setup () {

--- a/src/views/Returns.vue
+++ b/src/views/Returns.vue
@@ -108,6 +108,9 @@ export default defineComponent({
     this.store.dispatch('return/fetchValidReturnStatuses');
   },
   ionViewDidEnter(){
+    if (this.$route.query.segment){
+      this.selectedSegment = this.$route.query.segment.toString();
+    }    
     this.getReturns();
   },
   methods: {

--- a/src/views/Shipments.vue
+++ b/src/views/Shipments.vue
@@ -105,6 +105,9 @@ export default defineComponent({
     }
   },
   ionViewWillEnter () {
+    if (this.$route.query.segment){
+      this.selectedSegment = this.$route.query.segment.toString();
+    }
     this.getShipments();
   },
   methods: {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
#428 
#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When the user navigates from the details page of a shipment, return, or purchase order, the "Open" segment is selected by default. Otherwise, the "Completed" segment is selected.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)