### PR TITLE
Improved: QOH on the cube icon will now display negative values as well (#425)

### DIFF
--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -48,7 +48,7 @@
             </div>
 
             <div class="location">
-              <ion-button v-if="productQoh[item.productId] === '' || !(productQoh[item.productId] >= 0)" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
+              <ion-button v-if="productQoh[item.productId] === ''" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
                 <ion-icon color="medium" slot="icon-only" :icon="cubeOutline" />
               </ion-button>
               <ion-chip v-else outline>
@@ -215,7 +215,7 @@ export default defineComponent({
         entries.forEach((entry: any) => {
           if (entry.isIntersecting) {
             const productId = entry.target.getAttribute('data-product-id');
-            if (productId && !(this.productQoh[productId] >= 0)) {
+            if (productId && !this.productQoh[productId]) {
               this.fetchQuantityOnHand(productId);
             }
           }

--- a/src/views/ShipmentDetails.vue
+++ b/src/views/ShipmentDetails.vue
@@ -48,7 +48,7 @@
             </div>
 
             <div class="location">
-              <ion-button v-if="productQoh[item.productId] === '' || !(productQoh[item.productId] >= 0)" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
+              <ion-button v-if="productQoh[item.productId] === ''" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
                 <ion-icon color="medium" slot="icon-only" :icon="cubeOutline" />
               </ion-button>
               <ion-chip v-else outline>
@@ -206,7 +206,7 @@ export default defineComponent({
         entries.forEach((entry: any) => {
           if (entry.isIntersecting) {
             const productId = entry.target.getAttribute('data-product-id');
-            if (productId && !(this.productQoh[productId] >= 0)) {
+            if (productId && !this.productQoh[productId]) {
               this.fetchQuantityOnHand(productId);
             }
           }


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#425

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Previously, clicking on the cube icon only displayed the product's positive QOH (Quantity on Hand).
- After this change, negative QOH values are also displayed.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/fe09550b-eb63-4a62-bee6-9941e2e843fb)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)