### PR TITLE
Fixed: Incorrect Tab Opens After Navigating Between Sections from Order Details Page (#428)

### DIFF
--- a/src/views/PurchaseOrders.vue
+++ b/src/views/PurchaseOrders.vue
@@ -147,9 +147,13 @@ export default defineComponent({
     },
     segmentChanged() {
       this.getPurchaseOrders();
+    },
+    ionViewDidLeave() {
+      this.selectedSegment = this.selectedSegment === "completed" ? "completed" : "open";
     }
   },
   ionViewWillEnter () {
+    this.selectedSegment = "open"
     this.getPurchaseOrders();
   },
   setup () {

--- a/src/views/PurchaseOrders.vue
+++ b/src/views/PurchaseOrders.vue
@@ -147,13 +147,9 @@ export default defineComponent({
     },
     segmentChanged() {
       this.getPurchaseOrders();
-    },
-    ionViewDidLeave() {
-      this.selectedSegment = this.selectedSegment === "completed" ? "completed" : "open";
     }
   },
   ionViewWillEnter () {
-    this.selectedSegment = "open"
     this.getPurchaseOrders();
   },
   setup () {

--- a/src/views/PurchaseOrders.vue
+++ b/src/views/PurchaseOrders.vue
@@ -70,6 +70,7 @@ import { defineComponent, computed } from 'vue';
 import { mapGetters, useStore } from 'vuex';
 import PurchaseOrderItem from '@/components/PurchaseOrderItem.vue'
 import { translate, useUserStore } from "@hotwax/dxp-components"
+import { useRouter } from 'vue-router';
 
 export default defineComponent({
   name: 'PurchaseOrders',
@@ -150,9 +151,12 @@ export default defineComponent({
     }
   },
   ionViewWillEnter () {
+    const forwardRoute = this.router.options.history.state.forward as any;
+    if(!forwardRoute?.startsWith('/purchase-order-detail/')) this.selectedSegment = "open";
     this.getPurchaseOrders();
   },
   setup () {
+    const router = useRouter();
     const store = useStore();
     const userStore = useUserStore()
     let currentFacility: any = computed(() => userStore.getCurrentFacility) 
@@ -161,6 +165,7 @@ export default defineComponent({
       cloudDownloadOutline,
       currentFacility,
       reload,
+      router,
       store,
       translate
     }

--- a/src/views/Returns.vue
+++ b/src/views/Returns.vue
@@ -108,6 +108,7 @@ export default defineComponent({
     this.store.dispatch('return/fetchValidReturnStatuses');
   },
   ionViewDidEnter(){
+    this.selectedSegment = "open"
     this.getReturns();
   },
   methods: {
@@ -167,6 +168,9 @@ export default defineComponent({
     },
     segmentChanged() {
       this.getReturns();
+    },
+    ionViewDidLeave() {
+      this.selectedSegment = this.selectedSegment === "completed" ? "completed" : "open";
     }
   },
   setup() {

--- a/src/views/Returns.vue
+++ b/src/views/Returns.vue
@@ -108,7 +108,6 @@ export default defineComponent({
     this.store.dispatch('return/fetchValidReturnStatuses');
   },
   ionViewDidEnter(){
-    this.selectedSegment = "open"
     this.getReturns();
   },
   methods: {
@@ -168,9 +167,6 @@ export default defineComponent({
     },
     segmentChanged() {
       this.getReturns();
-    },
-    ionViewDidLeave() {
-      this.selectedSegment = this.selectedSegment === "completed" ? "completed" : "open";
     }
   },
   setup() {

--- a/src/views/Returns.vue
+++ b/src/views/Returns.vue
@@ -71,6 +71,7 @@ import { defineComponent, computed } from 'vue'
 import { mapGetters, useStore } from 'vuex'
 import ReturnListItem from '@/components/ReturnListItem.vue'
 import { translate, useUserStore } from "@hotwax/dxp-components"
+import { useRouter } from 'vue-router';
 
 export default defineComponent({
   name: "Returns",
@@ -108,6 +109,8 @@ export default defineComponent({
     this.store.dispatch('return/fetchValidReturnStatuses');
   },
   ionViewDidEnter(){
+    const forwardRoute = this.router.options.history.state.forward as any;
+    if(!forwardRoute?.startsWith('/return/')) this.selectedSegment = "open";
     this.getReturns();
   },
   methods: {
@@ -170,6 +173,7 @@ export default defineComponent({
     }
   },
   setup() {
+    const router = useRouter()
     const store = useStore();
     const userStore = useUserStore()
     let currentFacility: any = computed(() => userStore.getCurrentFacility) 
@@ -178,6 +182,7 @@ export default defineComponent({
       cloudDownloadOutline,
       currentFacility,
       reload,
+      router,
       store,
       translate
     }

--- a/src/views/Shipments.vue
+++ b/src/views/Shipments.vue
@@ -71,6 +71,7 @@ import { defineComponent, computed } from 'vue'
 import { mapGetters, useStore } from 'vuex'
 import ShipmentListItem from '@/components/ShipmentListItem.vue'
 import { translate, useUserStore } from "@hotwax/dxp-components"
+import { useRouter } from 'vue-router';
 
 export default defineComponent({
   name: "Shipments",
@@ -105,6 +106,9 @@ export default defineComponent({
     }
   },
   ionViewWillEnter () {
+    // Using forward instead of back property because when navigating back from a details page, the details page route is stored in forward property in router.
+    const forwardRoute = this.router.options.history.state.forward as any;
+    if(!forwardRoute?.startsWith('/shipment/')) this.selectedSegment = "open";
     this.getShipments();
   },
   methods: {
@@ -169,6 +173,7 @@ export default defineComponent({
     }
   },
   setup() {
+    const router = useRouter()
     const store = useStore();
     const userStore = useUserStore()
     let currentFacility: any = computed(() => userStore.getCurrentFacility) 
@@ -177,6 +182,7 @@ export default defineComponent({
       cloudDownloadOutline,
       currentFacility,
       reload,
+      router,
       store,
       translate
     }

--- a/src/views/Shipments.vue
+++ b/src/views/Shipments.vue
@@ -105,6 +105,7 @@ export default defineComponent({
     }
   },
   ionViewWillEnter () {
+    this.selectedSegment = "open"
     this.getShipments();
   },
   methods: {
@@ -166,6 +167,9 @@ export default defineComponent({
     },
     segmentChanged() {
       this.getShipments()
+    },
+    ionViewDidLeave() {
+      this.selectedSegment = this.selectedSegment === "completed" ? "completed" : "open";
     }
   },
   setup() {

--- a/src/views/Shipments.vue
+++ b/src/views/Shipments.vue
@@ -105,7 +105,6 @@ export default defineComponent({
     }
   },
   ionViewWillEnter () {
-    this.selectedSegment = "open"
     this.getShipments();
   },
   methods: {
@@ -167,9 +166,6 @@ export default defineComponent({
     },
     segmentChanged() {
       this.getShipments()
-    },
-    ionViewDidLeave() {
-      this.selectedSegment = this.selectedSegment === "completed" ? "completed" : "open";
     }
   },
   setup() {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#428 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Fixed a navigation issue where selectedSegment was not set to "open" when navigating back from a page other than the details page.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)