### PR TITLE
Fixed: Handled the case of emptying the product list on invalid search in AddProductToPOModal (#395)

### DIFF
--- a/src/store/modules/product/actions.ts
+++ b/src/store/modules/product/actions.ts
@@ -54,9 +54,11 @@ const actions: ActionTree<ProductState, RootState> = {
         if (payload.viewIndex && payload.viewIndex > 0) products = state.list.items.concat(products)
         commit(types.PRODUCT_LIST_UPDATED, { products, total });
         commit(types.PRODUCT_ADD_TO_CACHED_MULTIPLE, { products });
+      } else {
+        throw resp.data.docs;
       }
     } catch (error) {
-      showToast(translate("Something went wrong"));
+      commit(types.PRODUCT_LIST_UPDATED, { products: [], total: 0 });
     }
     if (payload.viewIndex === 0) emitter.emit("dismissLoader");
     
@@ -74,7 +76,7 @@ const actions: ActionTree<ProductState, RootState> = {
     }
   },
   async clearSearchedProducts({ commit }) {
-    commit(types.PRODUCT_LIST_UPDATED, { products: {}, total: 0 })
+    commit(types.PRODUCT_LIST_UPDATED, { products: [], total: 0 })
   }
 }
 


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#395 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Previously, the findProduct action did not clear the product list state when the API returned an empty response, resulting in the previous list persisting on an invalid search instead of displaying an empty state.
- Added logic to clear the product state in this case, which fixed the issue.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)