### PR TITLE
Fixed: improved error handling and pagination logic in transfer order actions and view. (#476)

### DIFF
--- a/src/store/modules/transferorder/actions.ts
+++ b/src/store/modules/transferorder/actions.ts
@@ -18,7 +18,7 @@ const actions: ActionTree<TransferOrderState, RootState> = {
 
     try {
       resp = await TransferOrderService.fetchTransferOrders(params);
-      if (resp.status === 200 && !hasError(resp) && resp.data.orders?.length > 0) {
+      if (!hasError(resp) && resp.data.ordersCount > 0) {
         total = resp.data.ordersCount;
         if (params.pageIndex && params.pageIndex > 0) {
           orders = state.transferOrder.list.concat(resp.data.orders);

--- a/src/store/modules/transferorder/actions.ts
+++ b/src/store/modules/transferorder/actions.ts
@@ -33,12 +33,11 @@ const actions: ActionTree<TransferOrderState, RootState> = {
           commit(types.ORDER_TRANSFER_UPDATED, { list: [], total: 0 });
         }
       }
-        } catch (err) {
-          console.error('No transfer orders found', err);
-          showToast(translate("Something went wrong"));
-          commit(types.ORDER_TRANSFER_UPDATED, { list: [], total: 0 });
-        }
-  
+    } catch (err) {
+      console.error('No transfer orders found', err);
+      showToast(translate("Something went wrong"));
+      commit(types.ORDER_TRANSFER_UPDATED, { list: [], total: 0 });
+    }
     commit(types.ORDER_TRANSFER_QUERY_UPDATED, { ...transferOrderQuery });
     return resp;
   },

--- a/src/views/TransferOrders.vue
+++ b/src/views/TransferOrders.vue
@@ -95,7 +95,8 @@ export default defineComponent({
       queryString: '',
       fetchingOrders: false,
       showErrorMessage: false,
-      selectedSegment: "open"
+      selectedSegment: "open",
+      currentPageIndex: 0
     }
   },
   computed: {
@@ -109,7 +110,7 @@ export default defineComponent({
       this.queryString ? this.showErrorMessage = true : this.showErrorMessage = false;
       this.fetchingOrders = true;
       const limit = vSize ? vSize : process.env.VUE_APP_VIEW_SIZE;
-      const pageIndex = vIndex ? vIndex : 0;
+      const pageIndex = vIndex ? vIndex : this.currentPageIndex;
 
       let orderStatusId;
       if (this.selectedSegment === 'open') {
@@ -130,19 +131,21 @@ export default defineComponent({
       await this.store.dispatch('transferorder/fetchTransferOrders', payload);
       emitter.emit('dismissLoader');
       this.fetchingOrders = false;
+      if (vIndex !== undefined) this.currentPageIndex = pageIndex;
       return Promise.resolve();
     },
     async loadMoreOrders() {
       const limit = process.env.VUE_APP_VIEW_SIZE;
-      const pageIndex = Math.ceil(this.orders.list.length / limit);
-      await this.getTransferOrders(limit, pageIndex);
+      await this.getTransferOrders(limit, this.currentPageIndex + 1);
     },
     async refreshTransferOrders(event?: any) {
+      this.currentPageIndex = 0;
       this.getTransferOrders().then(() => {
         if (event) event.target.complete();
       })
     },
     segmentChanged() {
+      this.currentPageIndex = 0;
       this.getTransferOrders();
     }
   },

--- a/src/views/TransferOrders.vue
+++ b/src/views/TransferOrders.vue
@@ -95,8 +95,7 @@ export default defineComponent({
       queryString: '',
       fetchingOrders: false,
       showErrorMessage: false,
-      selectedSegment: "open",
-      currentPageIndex: 0
+      selectedSegment: "open"
     }
   },
   computed: {
@@ -110,7 +109,7 @@ export default defineComponent({
       this.queryString ? this.showErrorMessage = true : this.showErrorMessage = false;
       this.fetchingOrders = true;
       const limit = vSize ? vSize : process.env.VUE_APP_VIEW_SIZE;
-      const pageIndex = vIndex ? vIndex : this.currentPageIndex;
+      const pageIndex = vIndex ? vIndex : 0;
 
       let orderStatusId;
       if (this.selectedSegment === 'open') {
@@ -131,21 +130,19 @@ export default defineComponent({
       await this.store.dispatch('transferorder/fetchTransferOrders', payload);
       emitter.emit('dismissLoader');
       this.fetchingOrders = false;
-      if (vIndex !== undefined) this.currentPageIndex = pageIndex;
       return Promise.resolve();
     },
     async loadMoreOrders() {
       const limit = process.env.VUE_APP_VIEW_SIZE;
-      await this.getTransferOrders(limit, this.currentPageIndex + 1);
+      const pageIndex = Math.ceil(this.orders.list.length / limit);
+      await this.getTransferOrders(limit, pageIndex);
     },
     async refreshTransferOrders(event?: any) {
-      this.currentPageIndex = 0;
       this.getTransferOrders().then(() => {
         if (event) event.target.complete();
       })
     },
     segmentChanged() {
-      this.currentPageIndex = 0;
       this.getTransferOrders();
     }
   },


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#476 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Enhanced transfer order pagination:
On initial load, the order list is replaced with new results or cleared if none are found.
On "Load More", new results are concatenated to the existing list; if no more results, a toast ("Transfer orders not found") is shown and the list is not updated.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
[Screencast from 22-05-25 12:48:09 PM IST.webm](https://github.com/user-attachments/assets/2e504015-12b0-41df-85d5-3dabcb5aea3d)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)