### PR TITLE
Fixed: logic of getFeatures method to return the correct value(#482)

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -69,7 +69,7 @@ const hasWebcamAccess = async () => {
 const getFeatures = (productFeatures: any) => {
   const features = productFeatures
     ?.sort((firstFeature: string, secondFeature: string) => firstFeature.split('/')[0].localeCompare(secondFeature.split('/')[0]))
-    ?.map((feature: string) => feature.split('/')[1])
+    ?.map((feature: string) => feature.substring(feature.indexOf("/") + 1)) // Not using split method as we may have features with value as `Size/N/S` and thus the only value returned is N when accessing 1st index considering that 1st index will have actual feature value, so we need to have some additional handling in case of split method
     ?.join(' ');
   return features || "";
 }


### PR DESCRIPTION
As we have used split method for separating feature key & value and used / as a separator, but there are cases where the value contains a / resulting in wrong feature value being dispalyed on the UI, thus replaced split method with a combination of substring and indexOf method to have correct feature value

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

# 482

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)