### PR TITLE
Fixed: update condition to check for orders length instead of orderCount  in fetchTransferOrders action. (#494)

### DIFF
--- a/src/store/modules/transferorder/actions.ts
+++ b/src/store/modules/transferorder/actions.ts
@@ -18,7 +18,7 @@ const actions: ActionTree<TransferOrderState, RootState> = {
 
     try {
       resp = await TransferOrderService.fetchTransferOrders(params);
-      if (!hasError(resp) && resp.data.ordersCount > 0) {
+      if (!hasError(resp) && resp.data.orders.length > 0) {
         total = resp.data.ordersCount;
         if (params.pageIndex && params.pageIndex > 0) {
           orders = state.transferOrder.list.concat(resp.data.orders);


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#494 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Update condition to check for orders length instead of orderCount  in fetchTransferOrders action.
It checks for array item, if there are item the list is incremented, else the error toast is shown.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
[Screencast from 27-05-25 06:58:35 PM IST.webm](https://github.com/user-attachments/assets/97b87666-b78e-4b77-8fb4-3b1068feb13d)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)