### PR TITLE
Fixed: Ensure totalReceivedQuantity is returns a number in TransferOrderDetail.vue. (#497)

### DIFF
--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -123,7 +123,7 @@
 
             <div>
               <ion-item lines="none">
-                <ion-label slot="end">{{ translate("/ received", { receivedCount: item.totalReceivedQuantity, orderedCount: item.quantity }) }}</ion-label>
+                <ion-label slot="end">{{ translate("/ received", { receivedCount: Number(item.totalReceivedQuantity), orderedCount: item.quantity }) }}</ion-label>
                 <ion-icon :icon="(item.totalReceivedQuantity == item.quantity) ? checkmarkDoneCircleOutline : warningOutline" :color="(item.totalReceivedQuantity  == item.quantity) ? '' : 'warning'" slot="end" />
               </ion-item>
             </div>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#497

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Ensure totalReceivedQuantity is returns a number in TransferOrderDetail.vue.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
[Screencast from 02-06-25 03:53:35 PM IST.webm](https://github.com/user-attachments/assets/ff98337e-8f7b-4934-8605-fbd8ab87ae9b)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)