### PR TITLE
Improved: Added a check to disable items that are not in 'Pending Receipt' status on the Receive and Close modal (#1222).

### DIFF
--- a/src/components/CloseTransferOrderModal.vue
+++ b/src/components/CloseTransferOrderModal.vue
@@ -157,7 +157,7 @@ export default defineComponent({
       return this.order.items.some((item: any) => item.isChecked && this.isTOItemStatusPending(item))
     },
     isTOItemStatusPending(item: any) {
-      return item.statusId !== "ITEM_COMPLETED" && item.statusId !== "ITEM_REJECTED"
+      return item.statusId === "ITEM_PENDING_RECEIPT"
     },
     selectAllItems() {
       this.order.items.map((item:any) => {


### PR DESCRIPTION


### Related Issues
#1222

#

### Short Description and Why It's Useful
Improved: Added a check to disable items that are not in 'Pending Receipt' status on the Receive and Close modal (#1222).


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)