### PR TITLE
Fixed: Item receipts history modal showing wrong data in case multiple line items with same product exists in TO (#519).

### DIFF
--- a/src/views/ReceivingHistoryModal.vue
+++ b/src/views/ReceivingHistoryModal.vue
@@ -77,6 +77,7 @@ export default defineComponent({
   },
   props: {
     productId: String,
+    orderItemSeqId: String,
     orderType: {
       type: String,
       default: 'purchaseOrder',
@@ -92,9 +93,14 @@ export default defineComponent({
     items() {
       const history = this.orderType === 'purchaseOrder' ? this.poHistory : this.toHistory;
       if (!history?.items) return [];
-      return this.productId
-        ? history.items.filter(item => item.productId === this.productId)
-        : history.items;
+      
+      if (this.orderItemSeqId) {
+        return history.items.filter(item => item.orderItemSeqId === this.orderItemSeqId)
+      } else if (this.productId) {
+        return history.items.filter(item => item.productId === this.productId)
+      } else {
+        return history.items;
+      }
     },
     emptyStateMessage() {
       if (this.productId) {

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -93,7 +93,7 @@
               </div>
 
               <div class="to-item-history">
-                <ion-chip outline @click="receivingHistory(item.productId)">
+                <ion-chip outline @click="receivingHistory(item.productId, item.orderItemSeqId)">
                   <ion-icon :icon="checkmarkDone"/>
                   <ion-label> {{ item.totalReceivedQuantity ?? 0 }} {{ translate("received") }} </ion-label>
                 </ion-chip>
@@ -363,12 +363,13 @@ export default defineComponent({
       })
       return modal.present();
     },
-    async receivingHistory(productId?: string) {
+    async receivingHistory(productId?: string, orderItemSeqId?: string) {
       const modal = await modalController
         .create({
           component: ReceivingHistoryModal,
           componentProps: {
             productId,
+            orderItemSeqId,
             orderType: 'transferOrder'
           }
         })


### PR DESCRIPTION


### Related Issues
#519 

#

### Short Description and Why It's Useful
Fixed: Item receipts history modal showing wrong data in case multiple line items with same product exists in TO .


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)