### PR TITLE
Show Tracking Number on Transfer Order Details Page #534

### DIFF
--- a/src/services/TransferOrderService.ts
+++ b/src/services/TransferOrderService.ts
@@ -32,6 +32,21 @@ const fetchTransferOrderDetail = async (orderId: string): Promise<any> => {
   });
 };
 
+const fetchOrderTrackingDetails = async (orderId: string): Promise<any> => {
+  const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
+  const baseURL = store.getters['user/getMaargBaseUrl'];
+
+  return client({
+    url: `poorti/transferShipments/packages?orderId=${orderId}`,
+    method: "get",
+    baseURL,
+    headers: {
+      "api_key": omsRedirectionInfo.token,
+      "Content-Type": "application/json"
+    }
+  });
+};
+
 const receiveTransferOrder = async (orderId: string, payload: any): Promise<any> => {
   const omsRedirectionInfo = store.getters['user/getOmsRedirectionInfo'];
   const baseURL = store.getters['user/getMaargBaseUrl'];
@@ -68,5 +83,6 @@ export const TransferOrderService = {
   fetchTransferOrders,
   fetchTransferOrderDetail,
   receiveTransferOrder,
-  fetchTransferOrderHistory
+  fetchTransferOrderHistory,
+  fetchOrderTrackingDetails
 };

--- a/src/store/modules/transferorder/actions.ts
+++ b/src/store/modules/transferorder/actions.ts
@@ -51,6 +51,13 @@ const actions: ActionTree<TransferOrderState, RootState> = {
 
       if (resp.status === 200 && !hasError(resp) && resp.data.order) {
         order = resp.data.order;
+        const trackingResp = await TransferOrderService.fetchOrderTrackingDetails(orderId);
+        if (!hasError(trackingResp) && trackingResp.data) {
+          order.shipmentPackages = trackingResp.data.shipmentPackages;
+        } else {
+          order.shipmentPackages = [];
+        }
+
         if (order.items && order.items.length) {
           this.dispatch('product/fetchProductInformation', { order: order.items });
         }

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -18,17 +18,17 @@
     <ion-content>
       <main>
         <div class="doc-id">
-          <ion-label class="ion-padding">
-            <h1>{{ translate("Transfer Order")}}: {{ order.externalId ? order.externalId : order.orderName ? order.orderName : order.orderId }}</h1>
-            <p>{{ translate("Item count") }}: {{ order.items?.length || 0 }}</p>
-            <p>
-              <ion-row>
-                <ion-col v-for="(pkg, index) in order.shipmentPackages" :key="index" size="auto" class="ion-padding-end">
-                  {{ pkg.trackingCode }}
-                </ion-col>
-              </ion-row>
-            </p>
-          </ion-label>
+          <div>
+            <ion-label class="ion-padding">
+              <h1>{{ translate("Transfer Order")}}: {{ order.externalId ? order.externalId : order.orderName ? order.orderName : order.orderId }}</h1>
+              <p>{{ translate("Item count") }}: {{ order.items?.length || 0 }}</p>
+            </ion-label>
+            <ion-row>
+              <ion-chip v-for="(pkg, index) in order.shipmentPackages" :key="index">
+                <ion-label>{{ pkg.trackingCode }}</ion-label>
+              </ion-chip>
+            </ion-row>
+          </div>
 
           <div class="doc-meta">
             <ion-chip @click="copyToClipboard(order.orderId, 'Internal ID saved to clipboard')">{{ order.orderId }}<ion-icon :icon="copyOutline"/></ion-chip>

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -21,6 +21,13 @@
           <ion-label class="ion-padding">
             <h1>{{ translate("Transfer Order")}}: {{ order.externalId ? order.externalId : order.orderName ? order.orderName : order.orderId }}</h1>
             <p>{{ translate("Item count") }}: {{ order.items?.length || 0 }}</p>
+            <p>
+              <ion-row>
+                <ion-col v-for="(pkg, index) in order.shipmentPackages" :key="index" size="auto" class="ion-padding-end">
+                  {{ pkg.trackingCode }}
+                </ion-col>
+              </ion-row>
+            </p>
           </ion-label>
 
           <div class="doc-meta">


### PR DESCRIPTION
### Related Issues
#534 

### Short Description and Why It's Useful
Display Tracking Number on Transfer Order Details Page

### Screenshots of Visual Changes before/after (If There Are Any)
Before:
<img width="1053" height="770" alt="image" src="https://github.com/user-attachments/assets/1a6e04fb-8fa4-410c-93af-ed50bdb8c265" />
After: 
<img width="1053" height="770" alt="image" src="https://github.com/user-attachments/assets/91de7869-1d68-4e23-81b8-c07e5ff91fcf" />

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)