### PR TITLE
fix: avoid rendering blank chips by filtering shipment packages with tracking codes (#534)

### DIFF
--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -24,7 +24,7 @@
               <p>{{ translate("Item count") }}: {{ order.items?.length || 0 }}</p>
             </ion-label>
             <ion-row>
-              <ion-chip v-for="(pkg, index) in order.shipmentPackages" :key="index">
+              <ion-chip v-for="(pkg, index) in trackedPackages" :key="index">
                 <ion-label>{{ pkg.trackingCode }}</ion-label>
               </ion-chip>
             </ion-row>
@@ -255,7 +255,10 @@ export default defineComponent({
       facilityLocationsByFacilityId: 'user/getFacilityLocationsByFacilityId',
       isForceScanEnabled: 'util/isForceScanEnabled',
       barcodeIdentifier: 'util/getBarcodeIdentificationPref',
-    })
+    }),
+    trackedPackages(): any[] {
+    return this.order?.shipmentPackages?.filter((pkg: any) => pkg.trackingCode) || [];
+  }
   },
   methods: {
     isItemReceivedInFull(item: any) {


### PR DESCRIPTION
### Related Issues
#534 

### Short Description and Why It's Useful
fix: avoid rendering blank chips by filtering shipment packages with tracking codes (#534)


### Screenshots of Visual Changes before/after (If There Are Any)
before: 
<img width="1228" height="576" alt="image" src="https://github.com/user-attachments/assets/1e37d1dd-e40e-4add-ba3d-91d4b1f3750b" />


after:
<img width="1303" height="565" alt="image" src="https://github.com/user-attachments/assets/ee580622-64d2-46a5-8a9b-f498a0c0b007" />



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)