### PR TITLE
fixed: update LocationPopover to trigger select on chip click and set…

### DIFF
--- a/src/components/LocationPopover.vue
+++ b/src/components/LocationPopover.vue
@@ -1,6 +1,6 @@
 <template>
-  <ion-chip outline>
-    <ion-select aria-label="Facility Location" interface="popover" :placeholder="translate('facility location')" :value="item.locationSeqId" @ionChange="setFacilityLocation($event)">
+  <ion-chip outline @click="openSelect">
+    <ion-select ref="facilitySelect" aria-label="Facility Location" interface="popover" :placeholder="translate('facility location')" :value="item.locationSeqId" @ionChange="setFacilityLocation($event)">
       <ion-icon slot="start" :icon="locationOutline"/>
       <ion-select-option v-for="facilityLocation in (getFacilityLocationsByFacilityId(facilityId) ? getFacilityLocationsByFacilityId(facilityId) : [])" :key="facilityLocation.locationSeqId" :value="facilityLocation.locationSeqId" >{{ facilityLocation.locationPath ? facilityLocation.locationPath : facilityLocation.locationSeqId }}</ion-select-option>
     </ion-select>
@@ -43,6 +43,12 @@ export default defineComponent({
         }
       }
     },
+    openSelect() {
+      const select = this.$refs.facilitySelect as any;
+      if (select && select.$el) {
+        select.$el.click();
+      }
+    }
   },
   setup() {
     const store = useStore();


### PR DESCRIPTION
### **Make Facility Selection chip fully clickable and show a dropdown**
 Ensure the entire Facility Selection chip area is interactive — not just the label — and that selecting a facility opens a dropdown-style selector.
 Users reported that only the label text was clickable, causing poor discoverability and inconsistent UI behavior (popover/modal showing in some cases). This change improves UX and makes selection consistent.

Reworked the component to reliably open a dropdown when the chip is clicked.

