### PR TITLE
Fixed: Newly created transfer orders now display the status (#570)

### DIFF
--- a/src/components/TransferOrderItem.vue
+++ b/src/components/TransferOrderItem.vue
@@ -6,7 +6,7 @@
       <p>{{ transferOrder.orderExternalId }}</p>
     </ion-label>
     <ion-label class="ion-text-end" slot="end">
-      <p>{{ transferOrder.orderDate ? getTime(transferOrder.orderDate) : '' }}</p>
+      <p v-if="transferOrder.orderDate">{{ getTime(transferOrder.orderDate) }}</p>
       <ion-badge :color="orderStatusColor[transferOrder.orderStatusId]">{{ transferOrder.orderStatusDesc }}</ion-badge>
     </ion-label>
   </ion-item>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#570 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Previously, when orderDate was not present in the order, the UI threw an error, preventing the status from being displayed.
- Handled the case for undefined orderDate, so the status now appears correctly.



### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)