### PR TITLE
Improved : toast messages for purchase order and returns same as transfers order format (#581)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -111,7 +111,7 @@
   "Return Details": "Return Details",
   "Return received successfully": "Return received successfully {shipmentId}",
   "Returns": "Returns",
-  "Return orders not found": "Return orders not found",
+  "Returns not found": "Returns not found",
   "rejected": "rejected",
   "Rejected": "Rejected",
   "returned": "returned",

--- a/src/store/modules/return/actions.ts
+++ b/src/store/modules/return/actions.ts
@@ -24,7 +24,7 @@ const actions: ActionTree<ReturnState, RootState> = {
         if (payload.viewIndex && payload.viewIndex > 0) returns = state.returns.list.concat(returns);
         commit(types.RETURN_LIST_UPDATED, returns )
       } else {
-        payload.viewIndex ? showToast(translate("Return orders not found")) : commit(types.RETURN_LIST_UPDATED, []);
+        payload.viewIndex ? showToast(translate("Returns not found")) : commit(types.RETURN_LIST_UPDATED, []);
       }
     } catch(error){
       console.error(error)


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#581

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- improved toast messages for purchase orders and returns in the same format as transfers order .

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)