### PR TITLE
Improved: Added checks to filter out the "Fulfill Only TO" (#571).

### DIFF
--- a/src/views/TransferOrders.vue
+++ b/src/views/TransferOrders.vue
@@ -122,6 +122,7 @@ export default defineComponent({
         orderStatusId,
         destinationFacilityId: this.currentFacility?.facilityId,
         excludeOriginFacilityIds: "REJECTED_ITM_PARKING",
+        statusFlowId: ["TO_Fulfill_And_Receive", "TO_Receive_Only"],
         limit,
         pageIndex,
         orderName: this.queryString


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#571 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Previously, on the Transfer Order list page in both Open and Completed segments, the Fulfill Only (TO_FULFILL_ONLY) orders were visible.
- Added a check in the Transfer Order GET API to filter out the Fulfill Only orders and show only those orders whose status flow includes the receiving process.



### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)