### PR TITLE
user should not navigate untill recieving is in process

### DIFF
--- a/src/components/ClosePurchaseOrderModal.vue
+++ b/src/components/ClosePurchaseOrderModal.vue
@@ -115,9 +115,14 @@ export default defineComponent({
           text: translate('Proceed'),
           role: 'proceed',
           handler: async() => {
+          // const success = await this.updatePOItemStatus();
+
+          // if (success) {
+          //   await modalController.dismiss();
+          //   this.router.push('/purchase-orders');
+          // }
             await this.updatePOItemStatus()
             modalController.dismiss()
-            this.router.push('/purchase-orders');
           }
         }]
       });
@@ -232,6 +237,8 @@ export default defineComponent({
         }
         this.store.dispatch("order/updatePurchaseOrders", { purchaseOrders })
       }
+      this.router.push('/purchase-orders');
+
     },
     isEligibleToClosePOItems() {
       return this.order.items.some((item: any) => item.isChecked && this.isPOItemStatusPending(item))


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

# 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
User should NOT be navigated away until receiving process is completed.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)