### PR TITLE
Fixed : User Redirected to PO List Before Receiving Completes, Allowing Reopen and Interrupting the Process (#596)

### DIFF
--- a/src/components/ClosePurchaseOrderModal.vue
+++ b/src/components/ClosePurchaseOrderModal.vue
@@ -69,6 +69,7 @@ import { OrderService } from "@/services/OrderService";
 import { DxpShopifyImg, translate, getProductIdentificationValue, useProductIdentificationStore } from '@hotwax/dxp-components';
 import { useRouter } from 'vue-router';
 import { copyToClipboard, getFeatures, hasError } from '@/utils';
+import emitter from '@/event-bus';
 
 export default defineComponent({
   name: "ClosePurchaseOrderModal",
@@ -115,7 +116,9 @@ export default defineComponent({
           text: translate('Proceed'),
           role: 'proceed',
           handler: async() => {
+            emitter.emit("presentLoader", {message: 'Receiving in-progress.', backdropDismiss: false});
             await this.updatePOItemStatus()
+            emitter.emit("dismissLoader");
             modalController.dismiss()
             this.router.push('/purchase-orders');
           }

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -138,9 +138,7 @@ const actions: ActionTree<OrderState, RootState> = {
             items: payload.items,
             isMultiReceivingEnabled: true
           }
-          emitter.emit("presentLoader", {message: 'Receiving in-progress.', backdropDismiss: false});
           await this.dispatch('shipment/receiveShipment', poShipment).catch((err) => console.error(err))
-          emitter.emit("dismissLoader");
         })
       } else {
         showToast(translate("Something went wrong"));

--- a/src/store/modules/shipment/actions.ts
+++ b/src/store/modules/shipment/actions.ts
@@ -223,7 +223,6 @@ const actions: ActionTree<ShipmentState, RootState> = {
 
         if (resp.status == 200 && !hasError(resp)) {
           showToast(translate("Shipment received successfully", { shipmentId: payload.shipmentId }))
-          emitter.emit("dismissLoader");
           return true;
         } else {
           throw resp.data;


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#596

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- handled async operation in createPurchaseShipment action.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)