### PR TITLE
Fixed: Added checks to prevent multiple API calls on different actions (#593)

### DIFF
--- a/src/components/ClosePurchaseOrderModal.vue
+++ b/src/components/ClosePurchaseOrderModal.vue
@@ -104,6 +104,7 @@ export default defineComponent({
       modalController.dismiss({ dismissed: true });
     },
     async confirmSave() {
+      let isUpdating = false;
       const alert = await alertController.create({
         header: translate('Close purchase order items'),
         message: translate("The selected items won't be available for receiving later."),
@@ -115,9 +116,14 @@ export default defineComponent({
           text: translate('Proceed'),
           role: 'proceed',
           handler: async() => {
+            // Prevent multiple API calls while one is in progress
+            if (isUpdating) return false;
+            
+            isUpdating = true;
             await this.updatePOItemStatus()
             modalController.dismiss()
             this.router.push('/purchase-orders');
+            isUpdating = false;
           }
         }]
       });

--- a/src/components/PurchaseOrderItem.vue
+++ b/src/components/PurchaseOrderItem.vue
@@ -37,13 +37,19 @@ export default defineComponent({
         ORDER_APPROVED: 'primary',
         ORDER_REJECTED: 'danger',
         ORDER_COMPLETED: 'success'
-      }
+      },
+      isLoading: false
     }
   },
   methods: {
     async getOrderDetail(orderId?: any) {
+      // Prevent multiple clicks while loading
+      if (this.isLoading) return;
+      
+      this.isLoading = true;
       await this.store.dispatch("order/getOrderDetail", {orderId})
       .then(() => this.router.push({ path: `/purchase-order-detail/${orderId}` }))
+      this.isLoading = false;
     }
   },
   setup() {

--- a/src/views/PurchaseOrders.vue
+++ b/src/views/PurchaseOrders.vue
@@ -136,6 +136,8 @@ export default defineComponent({
       return Promise.resolve();
     },
     async loadMoreOrders() {
+      // Prevent multiple API calls while one is in progress
+      if (this.fetchingOrders) return;
       this.getPurchaseOrders(
         undefined,
         Math.ceil(this.orders.length / process.env.VUE_APP_VIEW_SIZE)

--- a/src/views/Returns.vue
+++ b/src/views/Returns.vue
@@ -161,6 +161,8 @@ export default defineComponent({
       return Promise.resolve();
     },
     loadMoreReturns() {
+      // Prevent multiple API calls while one is in progress
+      if (this.fetchingReturns) return;
       this.getReturns(process.env.VUE_APP_VIEW_SIZE, Math.ceil(this.returns.length / process.env.VUE_APP_VIEW_SIZE));
     },
     async refreshReturns(event?: any) {

--- a/src/views/Shipments.vue
+++ b/src/views/Shipments.vue
@@ -161,6 +161,8 @@ export default defineComponent({
       return Promise.resolve();
     },
     loadMoreShipments() {
+      // Prevent multiple API calls while one is in progress
+      if (this.fetchingShipments) return;
       this.getShipments(process.env.VUE_APP_VIEW_SIZE, Math.ceil(this.shipments.length / process.env.VUE_APP_VIEW_SIZE));
     },
     async refreshShipments(event?: any) {

--- a/src/views/TransferOrders.vue
+++ b/src/views/TransferOrders.vue
@@ -135,6 +135,9 @@ export default defineComponent({
       return Promise.resolve();
     },
     async loadMoreOrders() {
+      // Prevent multiple API calls while one is in progress
+      if (this.fetchingOrders) return;
+
       const limit = process.env.VUE_APP_VIEW_SIZE;
       const pageIndex = Math.ceil(this.orders.list.length / limit);
       await this.getTransferOrders(limit, pageIndex);


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#593 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Handled various multiple API call cases:
- Load More option in all segments and tabs.
- Proceed button on the Close Purchase Order Items alert.
- Order label on the Purchase Orders page in both segments.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)