### PR TITLE
Improved: commented out the notification UI specific blocks to be not displayed, as oms dependencies are not merged

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,6 @@ VUE_APP_PERMISSION_ID="RECEIVING_APP_VIEW"
 VUE_APP_ALIAS={}
 VUE_APP_DEFAULT_LOG_LEVEL="error"
 VUE_APP_LOGIN_URL="http://launchpad.hotwax.io/login"
-VUE_APP_EMBEDDED_LAUNCHPAD_URL="https://hotwax-embedded-launchpad-dev.firebaseapp.com"
 VUE_APP_NOTIF_APP_ID=RECEIVING
 VUE_APP_NOTIF_ENUM_TYPE_ID=NOTIF_RECEIVING
 VUE_APP_FIREBASE_CONFIG={"apiKey": "","authDomain": "","databaseURL": "","projectId": "","storageBucket": "","messagingSenderId": "","appId": ""}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -151,12 +151,12 @@ const routes: Array<RouteRecordRaw> = [
       permissionId: "APP_TRANSFERORDERS_VIEW"
     }
   },
-  {
-    path: '/notifications',
-    name: "Notifications",
-    component: Notifications,
-    beforeEnter: authGuard,
-  }
+  // {
+  //   path: '/notifications',
+  //   name: "Notifications",
+  //   component: Notifications,
+  //   beforeEnter: authGuard,
+  // }
 ]
 
 const router = createRouter({

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -64,7 +64,7 @@
           </ion-item>
         </ion-card>
 
-        <ion-card v-if="notificationPrefs.length">
+        <!-- <ion-card v-if="notificationPrefs.length">
           <ion-card-header>
             <ion-card-title>
               {{ translate("Notification Preference") }}
@@ -78,7 +78,7 @@
               <ion-toggle :data-testid="`settings-page-notification-toggle-${pref.enumId}`" label-placement="start" @click.prevent="confirmNotificationPrefUpdate(pref.enumId, $event)" :checked="pref.isEnabled">{{ pref.description }}</ion-toggle>
             </ion-item>
           </ion-list>
-        </ion-card>
+        </ion-card> -->
 
         <ion-card>
           <ion-card-header>
@@ -99,7 +99,7 @@
 </template>
 
 <script lang="ts">
-import { IonAvatar, IonButton, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle, IonContent, IonHeader,IonIcon, IonItem, IonList, IonMenuButton, IonPage, IonSelect, IonSelectOption, IonTitle, IonToggle, IonToolbar, alertController } from '@ionic/vue';
+import { IonAvatar, IonButton, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle, IonContent, IonHeader,IonIcon, IonItem, IonMenuButton, IonPage, IonSelect, IonSelectOption, IonTitle, IonToggle, IonToolbar, alertController } from '@ionic/vue';
 import { computed, defineComponent } from 'vue';
 import { openOutline } from 'ionicons/icons'
 import { mapGetters, useStore } from 'vuex';
@@ -125,8 +125,7 @@ export default defineComponent({
     IonContent, 
     IonHeader, 
     IonIcon,
-    IonItem, 
-    IonList,
+    IonItem,
     IonMenuButton,
     IonPage, 
     IonSelect, 

--- a/src/views/TransferOrders.vue
+++ b/src/views/TransferOrders.vue
@@ -4,11 +4,11 @@
       <ion-toolbar>
         <ion-menu-button data-testid="transfer-orders-page-menu-btn" slot="start" />
         <ion-title>{{ translate("Transfer Orders") }}</ion-title>
-        <ion-buttons slot="end">
+        <!-- <ion-buttons slot="end">
           <ion-button data-testid="notifications-button" @click="viewNotifications()">
             <ion-icon slot="icon-only" :icon="notificationsOutline" :color="(unreadNotificationsStatus && notifications.length) ? 'primary' : ''" />
           </ion-button>
-        </ion-buttons>
+        </ion-buttons> -->
       </ion-toolbar>
       <div>
         <ion-searchbar data-testid="transfer-orders-page-search-input" :placeholder="translate('Search transfer orders')" v-model="queryString" @keyup.enter="queryString = $event.target.value; getTransferOrders()" />
@@ -55,7 +55,6 @@
 <script lang="ts">
 import {
   IonButton,
-  IonButtons,
   IonContent,
   IonHeader,
   IonIcon,
@@ -81,7 +80,6 @@ export default defineComponent({
   name: 'TransferOrders',
   components: {
     IonButton,
-    IonButtons,
     IonContent,
     IonHeader,
     IonIcon, 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Commented out notifications related UI blocks as the backend dependent code is not yet available.

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)