### PR TITLE
⚡ Bolt: memoize PO history items accepted quantity

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-22 - O(N*M) State Getters in Vue Lists
+**Learning:** Found a specific performance anti-pattern in the Pinia store getters (`getPOItemAccepted`), where a getter parameterized by `productId` performs an `O(M)` `filter().reduce()` operation over history items, and this getter is called inside `v-for` loops or computed properties for every item in an order list (`O(N)`). This creates an `O(N*M)` rendering bottleneck as the number of items and history grows.
+**Action:** When optimizing parameterized getters used in lists, memoize the underlying data transformation within the outer getter function by reducing the array to a hash map `O(M)`, returning a function that performs an `O(1)` map lookup.

--- a/src/store/order.ts
+++ b/src/store/order.ts
@@ -31,10 +31,7 @@ export const useOrderStore = defineStore("order", {
     isProductAvailableInOrder: (state) => (productId: string) => state.current.items.some((item: any) => item.productId === productId),
     getPOHistory: (state) => state.current.poHistory,
     getPOItemAccepted: (state) => {
-      // ⚡ Bolt: memoize PO history items accepted quantity
-      // 💡 What: Reduced poHistory.items into a map instead of running filter/reduce for every productId lookup.
-      // 🎯 Why: This getter is called in v-for loops. The previous O(M) lookup made rendering O(N * M).
-      // 📊 Impact: Reduces rendering complexity from O(N * M) to O(N + M).
+      // Memoize PO history items accepted quantity to optimize lookups in lists.
       const acceptedMap = state.current.poHistory.items?.reduce((acc: any, item: any) => {
         acc[item.productId] = (acc[item.productId] || 0) + (Number(item.quantityAccepted) || 0);
         return acc;

--- a/src/store/order.ts
+++ b/src/store/order.ts
@@ -36,7 +36,7 @@ export const useOrderStore = defineStore("order", {
       // 🎯 Why: This getter is called in v-for loops. The previous O(M) lookup made rendering O(N * M).
       // 📊 Impact: Reduces rendering complexity from O(N * M) to O(N + M).
       const acceptedMap = state.current.poHistory.items?.reduce((acc: any, item: any) => {
-        acc[item.productId] = (acc[item.productId] || 0) + item.quantityAccepted;
+        acc[item.productId] = (acc[item.productId] || 0) + (Number(item.quantityAccepted) || 0);
         return acc;
       }, {}) || {};
       return (productId: string) => acceptedMap[productId] || 0;

--- a/src/store/order.ts
+++ b/src/store/order.ts
@@ -30,10 +30,16 @@ export const useOrderStore = defineStore("order", {
     getCurrent: (state) => state.current,
     isProductAvailableInOrder: (state) => (productId: string) => state.current.items.some((item: any) => item.productId === productId),
     getPOHistory: (state) => state.current.poHistory,
-    getPOItemAccepted: (state) => (productId: string) => {
-      return state.current.poHistory.items
-        ?.filter((item: any) => item.productId === productId)
-        .reduce((sum: any, item: any) => sum + item.quantityAccepted, 0);
+    getPOItemAccepted: (state) => {
+      // ⚡ Bolt: memoize PO history items accepted quantity
+      // 💡 What: Reduced poHistory.items into a map instead of running filter/reduce for every productId lookup.
+      // 🎯 Why: This getter is called in v-for loops. The previous O(M) lookup made rendering O(N * M).
+      // 📊 Impact: Reduces rendering complexity from O(N * M) to O(N + M).
+      const acceptedMap = state.current.poHistory.items?.reduce((acc: any, item: any) => {
+        acc[item.productId] = (acc[item.productId] || 0) + item.quantityAccepted;
+        return acc;
+      }, {}) || {};
+      return (productId: string) => acceptedMap[productId] || 0;
     },
   },
   actions: {


### PR DESCRIPTION
⚡ Bolt: memoize PO history items accepted quantity

💡 What: Changed getPOItemAccepted to reduce poHistory.items into a map once per state change, rather than running filter/reduce for every productId lookup. Added inline comments mapping out the optimization.
🎯 Why: The getter was being called inside v-for loops for each item in the order, causing an O(N * M) rendering bottleneck where N is order items and M is history items.
📊 Impact: Reduces rendering complexity from O(N * M) to O(N + M), significantly improving performance on orders with many items and history entries.
🔬 Measurement: Verify rendering performance of purchase order details page with many items.

---
*PR created automatically by Jules for task [3816147162592482759](https://jules.google.com/task/3816147162592482759) started by @dt2patel*