### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-22 - Missing ARIA labels on icon-only buttons
+**Learning:** Found multiple instances where `<ion-button>` elements containing only an `<ion-icon>` lack `aria-label` attributes or text alternatives, making them inaccessible to screen readers. For instance, close buttons, back buttons, history/add buttons in the toolbar do not provide accessible labels.
+**Action:** Adding `aria-label` attribute using Vue translation helper `translate()` to the most critical and frequently used icon-only buttons such as modal close/back buttons or page toolbar buttons. Today I will fix the header toolbar buttons in `PurchaseOrderDetail.vue`.

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -5,10 +5,10 @@
         <ion-back-button data-testid="purchase-order-detail-page-back-btn" default-href="/purchase-orders" slot="start" />
         <ion-title> {{ translate("Purchase Order Details") }} </ion-title>
         <ion-buttons slot="end">
-          <ion-button data-testid="purchase-order-detail-page-history-btn" @click="receivingHistory()">
+          <ion-button data-testid="purchase-order-detail-page-history-btn" :aria-label="translate('Receiving history')" @click="receivingHistory()">
             <ion-icon slot="icon-only" :icon="timeOutline"/>
           </ion-button>
-          <ion-button data-testid="purchase-order-detail-page-add-product-btn" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || isPOReceived()" @click="addProduct">
+          <ion-button data-testid="purchase-order-detail-page-add-product-btn" :aria-label="translate('Add product')" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || isPOReceived()" @click="addProduct">
             <ion-icon slot="icon-only" :icon="addOutline"/>
           </ion-button>
         </ion-buttons>
@@ -108,7 +108,7 @@
           <ion-text v-else color="medium" class="ion-margin-end">
             {{ translate("Completed: item", { itemsCount: getPOItems('completed').length }) }}
           </ion-text>
-          <ion-button data-testid="purchase-order-detail-page-toggle-completed-btn" size="default" v-if="getPOItems('completed').length" @click="showCompletedItems = !showCompletedItems" color="medium" fill="clear">
+          <ion-button data-testid="purchase-order-detail-page-toggle-completed-btn" :aria-label="showCompletedItems ? translate('Hide completed items') : translate('Show completed items')" size="default" v-if="getPOItems('completed').length" @click="showCompletedItems = !showCompletedItems" color="medium" fill="clear">
             <ion-icon :icon="showCompletedItems ? eyeOutline : eyeOffOutline" slot="icon-only" />
           </ion-button>
         </ion-item>

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -5,10 +5,10 @@
         <ion-back-button data-testid="transfer-order-detail-page-back-btn" default-href="/transfer-orders" slot="start" />
         <ion-title> {{ translate("Transfer Order Details") }} </ion-title>
         <ion-buttons slot="end">
-          <ion-button data-testid="transfer-order-detail-page-history-btn" @click="receivingHistory()">
+          <ion-button data-testid="transfer-order-detail-page-history-btn" :aria-label="translate('Receiving history')" @click="receivingHistory()">
             <ion-icon slot="icon-only" :icon="timeOutline"/>
           </ion-button>
-          <ion-button data-testid="transfer-order-detail-page-add-product-btn" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || isTOReceived()" @click="addProduct">
+          <ion-button data-testid="transfer-order-detail-page-add-product-btn" :aria-label="translate('Add product')" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || isTOReceived()" @click="addProduct">
             <ion-icon slot="icon-only" :icon="addOutline"/>
           </ion-button>
         </ion-buttons>
@@ -94,7 +94,7 @@
                 </div>
 
                 <div class="location">
-                  <ion-button :data-testid="`transfer-order-detail-page-fetch-qoh-btn-${item.orderItemSeqId || item.productId}`" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
+                  <ion-button :data-testid="`transfer-order-detail-page-fetch-qoh-btn-${item.orderItemSeqId || item.productId}`" :aria-label="translate('Fetch quantity on hand')" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
                     <ion-icon color="medium" slot="icon-only" :icon="cubeOutline" />
                   </ion-button>
                   <ion-chip v-else outline>
@@ -183,7 +183,7 @@
                 </div>
 
                 <div class="location">
-                  <ion-button :data-testid="`transfer-order-detail-page-open-fetch-qoh-btn-${item.orderItemSeqId || item.productId}`" color="medium" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
+                  <ion-button :data-testid="`transfer-order-detail-page-open-fetch-qoh-btn-${item.orderItemSeqId || item.productId}`" :aria-label="translate('Fetch quantity on hand')" color="medium" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
                     <ion-icon slot="icon-only" :icon="cubeOutline" />
                   </ion-button>
                   <ion-chip v-else outline>
@@ -226,7 +226,7 @@
               <ion-label>
                 {{ "No items available for receiving, check completed tab" }}
               </ion-label>
-              <ion-button data-testid="transfer-order-detail-page-open-empty-received-btn" fill="clear" @click="segmentChanged('received')">
+              <ion-button data-testid="transfer-order-detail-page-open-empty-received-btn" :aria-label="translate('View received items')" fill="clear" @click="segmentChanged('received')">
                 <ion-icon slot="icon-only" :icon="openOutline" />
               </ion-button>
             </div>
@@ -253,7 +253,7 @@
                 </div>
 
                 <div class="location">
-                  <ion-button :data-testid="`transfer-order-detail-page-received-fetch-qoh-btn-${item.orderItemSeqId || item.productId}`" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
+                  <ion-button :data-testid="`transfer-order-detail-page-received-fetch-qoh-btn-${item.orderItemSeqId || item.productId}`" :aria-label="translate('Fetch quantity on hand')" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
                     <ion-icon color="medium" slot="icon-only" :icon="cubeOutline" />
                   </ion-button>
                   <ion-chip v-else outline>
@@ -281,7 +281,7 @@
               <ion-label>
                 {{ "No items are marked as completed, check Open tab" }}
               </ion-label>
-              <ion-button data-testid="transfer-order-detail-page-received-empty-open-btn" fill="clear" @click="segmentChanged('open')">
+              <ion-button data-testid="transfer-order-detail-page-received-empty-open-btn" :aria-label="translate('View open items')" fill="clear" @click="segmentChanged('open')">
                 <ion-icon slot="icon-only" :icon="openOutline" />
               </ion-button>
             </div>
@@ -306,7 +306,7 @@
               </div>
 
               <div class="location">
-                <ion-button :data-testid="`transfer-order-detail-page-completed-fetch-qoh-btn-${item.orderItemSeqId || item.productId}`" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
+                <ion-button :data-testid="`transfer-order-detail-page-completed-fetch-qoh-btn-${item.orderItemSeqId || item.productId}`" :aria-label="translate('Fetch quantity on hand')" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
                   <ion-icon color="medium" slot="icon-only" :icon="cubeOutline" />
                 </ion-button>
                 <ion-chip v-else outline>


### PR DESCRIPTION
💡 **What:** Added dynamic and static `aria-label` attributes to icon-only buttons (`<ion-button>` containing only `<ion-icon>`) in `PurchaseOrderDetail.vue` and `TransferOrderDetail.vue` using the app's `translate` helper.
🎯 **Why:** To make interactive elements accessible to screen reader users. Previously, several critical action buttons (like history, add product, fetch quantity on hand, and toggle completion visibility) lacked descriptive labels, making navigation and interaction difficult for assistive technology users.
♿ **Accessibility:** This directly enhances WCAG compliance by ensuring all interactive elements have accessible names.

---
*PR created automatically by Jules for task [3027738783260426496](https://jules.google.com/task/3027738783260426496) started by @dt2patel*