### PR TITLE
Fixed: issue on TO list page, as the order information is not being displayed

### DIFF
--- a/src/views/TransferOrders.vue
+++ b/src/views/TransferOrders.vue
@@ -133,7 +133,8 @@ export default defineComponent({
         limit,
         pageIndex,
         orderName: this.queryString?.trim() || undefined,  // Kept this for backward compatibility, can be removed once the changes are pushed on oms
-        keyword: this.queryString?.trim() || undefined
+        keyword: this.queryString?.trim() || undefined,
+        fieldsToSelect: "orderId,orderName,orderExternalId,orderStatusId,orderStatusDesc,facilityId,orderFacilityId,orderDate"
       };
 
       emitter.emit('presentLoader');


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
As we have added support for fieldsToSelect in the get#TransferOrders service in backend, the api response does not include all the information required on the list page as fieldsToSelect are not getting passed in the payload, because previously the list is hardcoded on backend.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before:

<img width="1764" height="1106" alt="image" src="https://github.com/user-attachments/assets/6ef1fd01-fd94-4ea6-96ad-db38afb02de1" />


After:

<img width="1764" height="1106" alt="image" src="https://github.com/user-attachments/assets/c0f70bba-1d39-4a22-b78e-a75658259ccb" />


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)