### PR TITLE
Update sorting: Latest POs first and sort items by primaryId

### DIFF
--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -341,11 +341,20 @@ export default defineComponent({
       this.queryString = ''
     },
     getPOItems(orderType: string) {
+      let items = [];
       if(orderType === 'completed'){
-        return this.order.items.filter((item: any) => item.orderItemStatusId === 'ITEM_COMPLETED')
+        items = this.order.items.filter((item: any) => item.orderItemStatusId === 'ITEM_COMPLETED')
       } else {
-        return this.order.items.filter((item: any) => item.orderItemStatusId !== 'ITEM_COMPLETED' && item.orderItemStatusId !== 'ITEM_REJECTED')
+        items = this.order.items.filter((item: any) => item.orderItemStatusId !== 'ITEM_COMPLETED' && item.orderItemStatusId !== 'ITEM_REJECTED')
       }
+      items.sort((a: any, b: any) => {
+        const productA = this.getProduct(a.productId);
+        const productB = this.getProduct(b.productId);
+        const primaryIdA = this.getProductIdentificationValue(this.productIdentificationPref.primaryId, productA) || '';
+        const primaryIdB = this.getProductIdentificationValue(this.productIdentificationPref.primaryId, productB) || '';
+        return primaryIdA.localeCompare(primaryIdB);
+      });
+      return items;
     },
     async addProduct() {
       const modal = await modalController

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -352,6 +352,12 @@ export default defineComponent({
         const productB = this.getProduct(b.productId);
         const primaryIdA = this.getProductIdentificationValue(this.productIdentificationPref.primaryId, productA) || '';
         const primaryIdB = this.getProductIdentificationValue(this.productIdentificationPref.primaryId, productB) || '';
+           
+        if (primaryIdA === primaryIdB) {
+          const positionA = productA.position ? parseInt(productA.position) : 0;
+          const positionB = productB.position ? parseInt(productB.position) : 0;
+          return positionA - positionB;
+        }
         return primaryIdA.localeCompare(primaryIdB);
       });
       return items;

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -40,16 +40,16 @@
         </div>
 
         <ion-item lines="none" v-if="!isPOReceived()">
-          <ion-label v-if="getPOItems('pending').length > 1" color="medium" class="ion-margin-end">
-            {{ translate("Pending: items", { itemsCount: getPOItems('pending').length }) }}
+          <ion-label v-if="pendingItems.length > 1" color="medium" class="ion-margin-end">
+            {{ translate("Pending: items", { itemsCount: pendingItems.length }) }}
           </ion-label>
           <ion-label v-else color="medium" class="ion-margin-end">
-            {{ translate("Pending: item", { itemsCount: getPOItems('pending').length }) }}
+            {{ translate("Pending: item", { itemsCount: pendingItems.length }) }}
           </ion-label>
         </ion-item>
 
         <template v-if="!isPOReceived()">
-          <ion-card :data-testid="`purchase-order-detail-page-pending-item-card-${item.orderItemSeqId || item.productId}`" v-for="(item, index) in getPOItems('pending')" v-show="item.orderItemStatusId !== 'ITEM_COMPLETED' && item.orderItemStatusId !== 'ITEM_REJECTED'" :key="index" :class="getProductIdentificationValue(barcodeIdentifier, getProduct(item.productId)) === lastScannedId ? 'scanned-item' : '' " :id="getProductIdentificationValue(barcodeIdentifier, getProduct(item.productId))">
+          <ion-card :data-testid="`purchase-order-detail-page-pending-item-card-${item.orderItemSeqId || item.productId}`" v-for="(item, index) in pendingItems" v-show="item.orderItemStatusId !== 'ITEM_COMPLETED' && item.orderItemStatusId !== 'ITEM_REJECTED'" :key="index" :class="getProductIdentificationValue(barcodeIdentifier, getProduct(item.productId)) === lastScannedId ? 'scanned-item' : '' " :id="getProductIdentificationValue(barcodeIdentifier, getProduct(item.productId))">
             <div  class="product">
               <div class="product-info">
                 <ion-item lines="none">
@@ -102,18 +102,18 @@
         </template>
 
         <ion-item lines="none" v-if="!isPOReceived()">
-          <ion-text v-if="getPOItems('completed').length > 1" color="medium" class="ion-margin-end">
-            {{ translate("Completed: items", { itemsCount: getPOItems('completed').length }) }}
+          <ion-text v-if="completedItems.length > 1" color="medium" class="ion-margin-end">
+            {{ translate("Completed: items", { itemsCount: completedItems.length }) }}
           </ion-text>
           <ion-text v-else color="medium" class="ion-margin-end">
-            {{ translate("Completed: item", { itemsCount: getPOItems('completed').length }) }}
+            {{ translate("Completed: item", { itemsCount: completedItems.length }) }}
           </ion-text>
-          <ion-button data-testid="purchase-order-detail-page-toggle-completed-btn" size="default" v-if="getPOItems('completed').length" @click="showCompletedItems = !showCompletedItems" color="medium" fill="clear">
+          <ion-button data-testid="purchase-order-detail-page-toggle-completed-btn" size="default" v-if="completedItems.length" @click="showCompletedItems = !showCompletedItems" color="medium" fill="clear">
             <ion-icon :icon="showCompletedItems ? eyeOutline : eyeOffOutline" slot="icon-only" />
           </ion-button>
         </ion-item>
         
-        <ion-card :data-testid="`purchase-order-detail-page-completed-item-card-${item.orderItemSeqId || item.productId}`" v-for="(item, index) in getPOItems('completed')" v-show="showCompletedItems && item.orderItemStatusId === 'ITEM_COMPLETED'" :key="index" :class="getProductIdentificationValue(barcodeIdentifier, getProduct(item.productId)) === lastScannedId ? 'scanned-item' : '' " :id="getProductIdentificationValue(barcodeIdentifier, getProduct(item.productId))">
+        <ion-card :data-testid="`purchase-order-detail-page-completed-item-card-${item.orderItemSeqId || item.productId}`" v-for="(item, index) in completedItems" v-show="showCompletedItems && item.orderItemStatusId === 'ITEM_COMPLETED'" :key="index" :class="getProductIdentificationValue(barcodeIdentifier, getProduct(item.productId)) === lastScannedId ? 'scanned-item' : '' " :id="getProductIdentificationValue(barcodeIdentifier, getProduct(item.productId))">
           <div class="product">
             <div class="product-info">
               <ion-item lines="none">
@@ -235,7 +235,15 @@ export default defineComponent({
       facilityLocationsByFacilityId: 'user/getFacilityLocationsByFacilityId',
       isForceScanEnabled: 'util/isForceScanEnabled',
       barcodeIdentifier: 'util/getBarcodeIdentificationPref',
-    })
+    }),
+    pendingItems(): any {
+      const items = this.order?.items?.filter((item: any) => item.orderItemStatusId !== 'ITEM_COMPLETED' && item.orderItemStatusId !== 'ITEM_REJECTED') || [];
+      return this.sortItems(items);
+    },
+    completedItems(): any {
+      const items = this.order?.items?.filter((item: any) => item.orderItemStatusId === 'ITEM_COMPLETED') || [];
+      return this.sortItems(items);
+    }
   },
   methods: {
     isItemReceivedInFull(item: any) {
@@ -340,18 +348,13 @@ export default defineComponent({
       }
       this.queryString = ''
     },
-    getPOItems(orderType: string) {
-      let items = [];
-      if(orderType === 'completed'){
-        items = this.order.items.filter((item: any) => item.orderItemStatusId === 'ITEM_COMPLETED')
-      } else {
-        items = this.order.items.filter((item: any) => item.orderItemStatusId !== 'ITEM_COMPLETED' && item.orderItemStatusId !== 'ITEM_REJECTED')
-      }
+    sortItems(items: any) {
       items.sort((a: any, b: any) => {
         const productA = this.getProduct(a.productId);
         const productB = this.getProduct(b.productId);
-        const primaryIdA = this.getProductIdentificationValue(this.productIdentificationPref.primaryId, productA) || '';
-        const primaryIdB = this.getProductIdentificationValue(this.productIdentificationPref.primaryId, productB) || '';
+        // primary identifier can not be null
+        const primaryIdA = this.getProductIdentificationValue(this.productIdentificationPref.primaryId, productA) || productA.productName || '';
+        const primaryIdB = this.getProductIdentificationValue(this.productIdentificationPref.primaryId, productB) || productB.productName || '';
            
         if (primaryIdA === primaryIdB) {
           const positionA = productA.position ? parseInt(productA.position) : 0;

--- a/src/views/PurchaseOrders.vue
+++ b/src/views/PurchaseOrders.vue
@@ -121,6 +121,7 @@ export default defineComponent({
             "group.field": "orderId",
             "group.limit": 10000,
             "group.ngroups": true,
+            "sort": "orderDate desc"
           } as any,
           "query": "*:*",
           "filter": `docType: ORDER AND orderTypeId: PURCHASE_ORDER AND orderStatusId: ${this.selectedSegment === 'open' ? '(ORDER_APPROVED OR ORDER_CREATED)' : 'ORDER_COMPLETED'} AND facilityId: ${this.currentFacility?.facilityId}`


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
https://github.com/hotwax/receiving/issues/666

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This Pull Request introduces two main enhancements to improve the sorting logic and usability in the Receiving App:
- **Purchase Orders List Sorting:** Updated the default sorting so that the most recent Purchase Orders always appear at the top based on their import/creation date (`orderDate desc`).
- **Product List Sorting:** Added a sorting mechanism inside the Purchase Order details view. The product list is now alphabetically sorted by the `primaryId` of the products, falling back to the product name if the primary ID is not available.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
N/A

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)
