### PR TITLE
refactor: update formatDate to use commonUtil and user-specific timezone instead of global filters

### DIFF
--- a/src/components/PurchaseOrderItem.vue
+++ b/src/components/PurchaseOrderItem.vue
@@ -16,14 +16,13 @@
 import { IonBadge, IonItem, IonLabel } from '@ionic/vue';
 import { useRouter } from 'vue-router';
 import { useOrderStore } from '@/store/order';
-import { getCurrentInstance } from 'vue';
+import { commonUtil } from '@common';
+import { useUserStore } from '@/store/user';
 
 const props = defineProps(["purchaseOrder"]);
 
 const router = useRouter();
 const orderStore = useOrderStore();
-const instance = getCurrentInstance();
-const filters = instance?.appContext.config.globalProperties.$filters;
 
 const orderStatusColor = {
   ORDER_CREATED: 'medium',
@@ -33,7 +32,7 @@ const orderStatusColor = {
 } as any;
 
 const formatDate = (value: string) => {
-  return filters?.formatUtcDate(value, 'YYYY-MM-DDTHH:mm:ssZ');
+  return commonUtil.formatUtcDate(value, useUserStore().current.timeZone);
 }
 
 const getOrderDetail = async (orderId: string) => {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

https://github.com/hotwax/receiving/issues/677

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR standardizes the date rendering in the `PurchaseOrderItem` component. It replaces the reliance on `$filters` fetched from Vue's `getCurrentInstance()` and a hardcoded date format string (`YYYY-MM-DDTHH:mm:ssZ`).

Instead, it utilizes `commonUtil.formatUtcDate` and extracts the user's timezone using `useUserStore().current.timeZone`. This ensures date formatting is more robust and correctly respects the user's active timezone configuration.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)