### PR TITLE
Vaibhavi/fix aria labels v3

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-22 - Missing ARIA labels on icon-only buttons
+**Learning:** Found multiple instances where `<ion-button>` elements containing only an `<ion-icon>` lack `aria-label` attributes or text alternatives, making them inaccessible to screen readers. For instance, close buttons, back buttons, history/add buttons in the toolbar do not provide accessible labels.
+**Action:** Adding `aria-label` attribute using Vue translation helper `translate()` to the most critical and frequently used icon-only buttons such as modal close/back buttons or page toolbar buttons. Today I will fix the header toolbar buttons in `PurchaseOrderDetail.vue`.

--- a/src/components/AddProductToTOModal.vue
+++ b/src/components/AddProductToTOModal.vue
@@ -2,7 +2,7 @@
   <ion-header>
     <ion-toolbar>
       <ion-buttons slot="start">
-        <ion-button data-testid="transfer-order-add-product-modal-close-btn" @click="closeModal">
+        <ion-button data-testid="transfer-order-add-product-modal-close-btn" :aria-label="translate('Close')" @click="closeModal">
           <ion-icon slot="icon-only" :icon="closeOutline" />
         </ion-button>
       </ion-buttons>

--- a/src/components/ClosePurchaseOrderModal.vue
+++ b/src/components/ClosePurchaseOrderModal.vue
@@ -1,8 +1,8 @@
 <template>
   <ion-header>
     <ion-toolbar>
-      <ion-buttons slot="start">
-        <ion-button data-testid="purchase-order-close-items-modal-back-btn" @click="closeModal">
+        <ion-buttons slot="start">
+        <ion-button data-testid="purchase-order-close-items-modal-back-btn" :aria-label="translate('Back')" @click="closeModal">
           <ion-icon slot="icon-only" :icon="arrowBackOutline" />
         </ion-button>
       </ion-buttons>

--- a/src/components/DxpProductIdentifier.vue
+++ b/src/components/DxpProductIdentifier.vue
@@ -34,7 +34,7 @@
           {{ commonUtil.getProductIdentificationValue(productIdentificationPref.primaryId, currentSampleProduct) ? commonUtil.getProductIdentificationValue(productIdentificationPref.primaryId, currentSampleProduct) : currentSampleProduct.productId }}
           <p>{{ commonUtil.getProductIdentificationValue(productIdentificationPref.secondaryId, currentSampleProduct) }}</p>
         </ion-label>
-        <ion-button size="default" fill="clear" @click="shuffle">  
+        <ion-button :aria-label="translate('Shuffle sample product')" size="default" fill="clear" @click="shuffle">  
           <ion-icon slot="icon-only" :icon="shuffleOutline"/>
         </ion-button>
       </ion-item>

--- a/src/components/NotificationPreferenceModal.vue
+++ b/src/components/NotificationPreferenceModal.vue
@@ -2,7 +2,7 @@
   <ion-header>
     <ion-toolbar>
       <ion-buttons slot="start">
-        <ion-button @click="closeModal"> 
+        <ion-button :aria-label="translate('Close')" @click="closeModal"> 
           <ion-icon slot="icon-only" :icon="closeOutline" />
         </ion-button>
       </ion-buttons>
@@ -20,7 +20,7 @@
       </ion-item>
     </ion-list>
     <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-      <ion-fab-button :disabled="isButtonDisabled" @click="confirmSave()">
+      <ion-fab-button :aria-label="translate('Save')" :disabled="isButtonDisabled" @click="confirmSave()">
         <ion-icon :icon="save" />
       </ion-fab-button>
     </ion-fab>

--- a/src/components/ReceiveTransferOrder.vue
+++ b/src/components/ReceiveTransferOrder.vue
@@ -2,7 +2,7 @@
   <ion-header>
     <ion-toolbar>
       <ion-buttons slot="start">
-        <ion-button data-testid="transfer-order-receive-modal-close-btn" @click="closeModal">
+        <ion-button data-testid="transfer-order-receive-modal-close-btn" :aria-label="translate('Back')" @click="closeModal">
           <ion-icon slot="icon-only" :icon="arrowBackOutline" />
         </ion-button>
       </ion-buttons>

--- a/src/components/ReceivingInstructions.vue
+++ b/src/components/ReceivingInstructions.vue
@@ -2,7 +2,7 @@
   <ion-header>
     <ion-toolbar>
       <ion-buttons slot="start">
-        <ion-button data-testid="transfer-order-receiving-instructions-modal-close-btn" @click="closeModal">
+        <ion-button data-testid="transfer-order-receiving-instructions-modal-close-btn" :aria-label="translate('Close')" @click="closeModal">
           <ion-icon slot="icon-only" :icon="closeOutline" />
         </ion-button>
       </ion-buttons>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -60,6 +60,8 @@
   "Go to Launchpad": "Go to Launchpad",
   "Go to OMS": "Go to OMS",
   "History": "History",
+  "View received items": "View received items",
+  "View open items": "View open items",
   "To close this order, enter the actual quantity received or enter '0' if the item was not received.": "To close this order, enter the actual quantity received or enter '0' if the item was not received.",
   "Internal ID saved to clipboard": "Internal ID saved to clipboard",
   "Inventory can be received for purchase orders in multiple shipments. Proceeding will receive a new shipment for this purchase order but it will still be available for receiving later": "Inventory can be received for purchase orders in multiple shipments. { space } Proceeding will receive a new shipment for this purchase order but it will still be available for receiving later",

--- a/src/views/AddProductModal.vue
+++ b/src/views/AddProductModal.vue
@@ -2,7 +2,7 @@
   <ion-header>
     <ion-toolbar>
       <ion-buttons slot="start">
-        <ion-button data-testid="shipment-add-product-modal-close-btn" @click="closeModal">
+        <ion-button data-testid="shipment-add-product-modal-close-btn" :aria-label="translate('Close')" @click="closeModal">
           <ion-icon slot="icon-only" :icon="closeOutline" />
         </ion-button>
       </ion-buttons>

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button data-testid="purchase-order-detail-page-back-btn" default-href="/purchase-orders" slot="start" />
+        <ion-back-button data-testid="purchase-order-detail-page-back-btn" :aria-label="translate('Back')" default-href="/purchase-orders" slot="start" />
         <ion-title> {{ translate("Purchase Order Details") }} </ion-title>
         <ion-buttons slot="end">
           <ion-button data-testid="purchase-order-detail-page-history-btn" :aria-label="translate('Receiving history')" @click="receivingHistory()">

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -5,10 +5,10 @@
         <ion-back-button data-testid="purchase-order-detail-page-back-btn" default-href="/purchase-orders" slot="start" />
         <ion-title> {{ translate("Purchase Order Details") }} </ion-title>
         <ion-buttons slot="end">
-          <ion-button data-testid="purchase-order-detail-page-history-btn" @click="receivingHistory()">
+          <ion-button data-testid="purchase-order-detail-page-history-btn" :aria-label="translate('Receiving history')" @click="receivingHistory()">
             <ion-icon slot="icon-only" :icon="timeOutline"/>
           </ion-button>
-          <ion-button data-testid="purchase-order-detail-page-add-product-btn" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || isPOReceived()" @click="addProduct">
+          <ion-button data-testid="purchase-order-detail-page-add-product-btn" :aria-label="translate('Add product')" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || isPOReceived()" @click="addProduct">
             <ion-icon slot="icon-only" :icon="addOutline"/>
           </ion-button>
         </ion-buttons>
@@ -108,7 +108,7 @@
           <ion-text v-else color="medium" class="ion-margin-end">
             {{ translate("Completed: item", { itemsCount: getPOItems('completed').length }) }}
           </ion-text>
-          <ion-button data-testid="purchase-order-detail-page-toggle-completed-btn" size="default" v-if="getPOItems('completed').length" @click="showCompletedItems = !showCompletedItems" color="medium" fill="clear">
+          <ion-button data-testid="purchase-order-detail-page-toggle-completed-btn" :aria-label="showCompletedItems ? translate('Hide completed items') : translate('Show completed items')" size="default" v-if="getPOItems('completed').length" @click="showCompletedItems = !showCompletedItems" color="medium" fill="clear">
             <ion-icon :icon="showCompletedItems ? eyeOutline : eyeOffOutline" slot="icon-only" />
           </ion-button>
         </ion-item>

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -5,10 +5,10 @@
         <ion-back-button data-testid="purchase-order-detail-page-back-btn" :aria-label="translate('Back')" default-href="/purchase-orders" slot="start" />
         <ion-title> {{ translate("Purchase Order Details") }} </ion-title>
         <ion-buttons slot="end">
-          <ion-button data-testid="purchase-order-detail-page-history-btn" :aria-label="translate('Receiving history')" @click="receivingHistory()">
+          <ion-button data-testid="purchase-order-detail-page-history-btn" :aria-label="translate('History')" @click="receivingHistory()">
             <ion-icon slot="icon-only" :icon="timeOutline"/>
           </ion-button>
-          <ion-button data-testid="purchase-order-detail-page-add-product-btn" :aria-label="translate('Add product')" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || isPOReceived()" @click="addProduct">
+          <ion-button data-testid="purchase-order-detail-page-add-product-btn" :aria-label="translate('Add a product')" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || isPOReceived()" @click="addProduct">
             <ion-icon slot="icon-only" :icon="addOutline"/>
           </ion-button>
         </ion-buttons>

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -48,7 +48,7 @@
             </div>
 
             <div class="location">
-              <ion-button :data-testid="`return-detail-page-fetch-qoh-btn-${item.itemSeqId || item.productId}`" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
+              <ion-button :aria-label="translate('Fetch quantity on hand')" :data-testid="`return-detail-page-fetch-qoh-btn-${item.itemSeqId || item.productId}`" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
                 <ion-icon color="medium" slot="icon-only" :icon="cubeOutline" />
               </ion-button>
               <ion-chip v-else outline>

--- a/src/views/ShipmentDetails.vue
+++ b/src/views/ShipmentDetails.vue
@@ -49,7 +49,7 @@
             </div>
 
             <div class="location">
-              <ion-button :data-testid="`shipment-detail-page-fetch-qoh-btn-${item.itemSeqId || item.productId}`" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
+              <ion-button :aria-label="translate('Fetch quantity on hand')" :data-testid="`shipment-detail-page-fetch-qoh-btn-${item.itemSeqId || item.productId}`" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
                 <ion-icon color="medium" slot="icon-only" :icon="cubeOutline" />
               </ion-button>
               <ion-chip v-else outline>

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -5,10 +5,10 @@
         <ion-back-button data-testid="transfer-order-detail-page-back-btn" default-href="/transfer-orders" slot="start" />
         <ion-title> {{ translate("Transfer Order Details") }} </ion-title>
         <ion-buttons slot="end">
-          <ion-button data-testid="transfer-order-detail-page-history-btn" @click="receivingHistory()">
+          <ion-button data-testid="transfer-order-detail-page-history-btn" :aria-label="translate('Receiving history')" @click="receivingHistory()">
             <ion-icon slot="icon-only" :icon="timeOutline"/>
           </ion-button>
-          <ion-button data-testid="transfer-order-detail-page-add-product-btn" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || isTOReceived()" @click="addProduct">
+          <ion-button data-testid="transfer-order-detail-page-add-product-btn" :aria-label="translate('Add product')" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || isTOReceived()" @click="addProduct">
             <ion-icon slot="icon-only" :icon="addOutline"/>
           </ion-button>
         </ion-buttons>
@@ -94,7 +94,7 @@
                 </div>
 
                 <div class="location">
-                  <ion-button :data-testid="`transfer-order-detail-page-fetch-qoh-btn-${item.orderItemSeqId || item.productId}`" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
+                  <ion-button :data-testid="`transfer-order-detail-page-fetch-qoh-btn-${item.orderItemSeqId || item.productId}`" :aria-label="translate('Fetch quantity on hand')" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
                     <ion-icon color="medium" slot="icon-only" :icon="cubeOutline" />
                   </ion-button>
                   <ion-chip v-else outline>
@@ -183,7 +183,7 @@
                 </div>
 
                 <div class="location">
-                  <ion-button :data-testid="`transfer-order-detail-page-open-fetch-qoh-btn-${item.orderItemSeqId || item.productId}`" color="medium" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
+                  <ion-button :data-testid="`transfer-order-detail-page-open-fetch-qoh-btn-${item.orderItemSeqId || item.productId}`" :aria-label="translate('Fetch quantity on hand')" color="medium" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
                     <ion-icon slot="icon-only" :icon="cubeOutline" />
                   </ion-button>
                   <ion-chip v-else outline>
@@ -226,7 +226,7 @@
               <ion-label>
                 {{ "No items available for receiving, check completed tab" }}
               </ion-label>
-              <ion-button data-testid="transfer-order-detail-page-open-empty-received-btn" fill="clear" @click="segmentChanged('received')">
+              <ion-button data-testid="transfer-order-detail-page-open-empty-received-btn" :aria-label="translate('View received items')" fill="clear" @click="segmentChanged('received')">
                 <ion-icon slot="icon-only" :icon="openOutline" />
               </ion-button>
             </div>
@@ -253,7 +253,7 @@
                 </div>
 
                 <div class="location">
-                  <ion-button :data-testid="`transfer-order-detail-page-received-fetch-qoh-btn-${item.orderItemSeqId || item.productId}`" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
+                  <ion-button :data-testid="`transfer-order-detail-page-received-fetch-qoh-btn-${item.orderItemSeqId || item.productId}`" :aria-label="translate('Fetch quantity on hand')" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
                     <ion-icon color="medium" slot="icon-only" :icon="cubeOutline" />
                   </ion-button>
                   <ion-chip v-else outline>
@@ -281,7 +281,7 @@
               <ion-label>
                 {{ "No items are marked as completed, check Open tab" }}
               </ion-label>
-              <ion-button data-testid="transfer-order-detail-page-received-empty-open-btn" fill="clear" @click="segmentChanged('open')">
+              <ion-button data-testid="transfer-order-detail-page-received-empty-open-btn" :aria-label="translate('View open items')" fill="clear" @click="segmentChanged('open')">
                 <ion-icon slot="icon-only" :icon="openOutline" />
               </ion-button>
             </div>
@@ -306,7 +306,7 @@
               </div>
 
               <div class="location">
-                <ion-button :data-testid="`transfer-order-detail-page-completed-fetch-qoh-btn-${item.orderItemSeqId || item.productId}`" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
+                <ion-button :data-testid="`transfer-order-detail-page-completed-fetch-qoh-btn-${item.orderItemSeqId || item.productId}`" :aria-label="translate('Fetch quantity on hand')" v-if="!productQoh[item.productId] && productQoh[item.productId] !== 0" fill="clear" @click.stop="fetchQuantityOnHand(item.productId)">
                   <ion-icon color="medium" slot="icon-only" :icon="cubeOutline" />
                 </ion-button>
                 <ion-chip v-else outline>

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -5,10 +5,10 @@
         <ion-back-button data-testid="transfer-order-detail-page-back-btn" :aria-label="translate('Back')" default-href="/transfer-orders" slot="start" />
         <ion-title> {{ translate("Transfer Order Details") }} </ion-title>
         <ion-buttons slot="end">
-          <ion-button data-testid="transfer-order-detail-page-history-btn" :aria-label="translate('Receiving history')" @click="receivingHistory()">
+          <ion-button data-testid="transfer-order-detail-page-history-btn" :aria-label="translate('History')" @click="receivingHistory()">
             <ion-icon slot="icon-only" :icon="timeOutline"/>
           </ion-button>
-          <ion-button data-testid="transfer-order-detail-page-add-product-btn" :aria-label="translate('Add product')" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || isTOReceived()" @click="addProduct">
+          <ion-button data-testid="transfer-order-detail-page-add-product-btn" :aria-label="translate('Add a product')" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || isTOReceived()" @click="addProduct">
             <ion-icon slot="icon-only" :icon="addOutline"/>
           </ion-button>
         </ion-buttons>

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button data-testid="transfer-order-detail-page-back-btn" default-href="/transfer-orders" slot="start" />
+        <ion-back-button data-testid="transfer-order-detail-page-back-btn" :aria-label="translate('Back')" default-href="/transfer-orders" slot="start" />
         <ion-title> {{ translate("Transfer Order Details") }} </ion-title>
         <ion-buttons slot="end">
           <ion-button data-testid="transfer-order-detail-page-history-btn" :aria-label="translate('Receiving history')" @click="receivingHistory()">


### PR DESCRIPTION
### Related Issues
#662

### Short Description and Why It's Useful
Added missing `aria-label` attributes to icon-only buttons and fixed 
incorrect translation keys to ensure screen readers receive actual text 
instead of undefined values. No functional code was changed.

### Screenshots of Visual Changes before/after (If There Are Any)
No visual changes — only accessibility labels updated.

### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)

## What
Two commits in this PR:

**Commit 1** — Added missing `aria-label` attributes to icon-only buttons:
- `AddProductToTOModal.vue`
- `ClosePurchaseOrderModal.vue`
- `DxpProductIdentifier.vue`
- `NotificationPreferenceModal.vue`
- `ReceiveTransferOrder.vue`
- `ReceivingInstructions.vue`
- `AddProductModal.vue`
- `PurchaseOrderDetail.vue`
- `ReturnDetails.vue`
- `ShipmentDetails.vue`
- `TransferOrderDetail.vue`

**Commit 2** — Fixed incorrect translation keys:
- `translate('Receiving history')` → `translate('History')`
- `translate('Add product')` → `translate('Add a product')`
- Added missing keys to `en.json`:
  - `"View received items": "View received items"`
  - `"View open items": "View open items"`

## Why
- Icon-only buttons lacked `aria-label`, making them inaccessible to 
  screen reader users.
- Some translation keys were missing from `en.json`, causing 
  `undefined` aria-label values.
- Fixes improve WCAG compliance without changing app behavior.