### PR TITLE
Prevent duplicate transfer order receive confirmations

### DIFF
--- a/src/composables/useReceiveFlowState.spec.ts
+++ b/src/composables/useReceiveFlowState.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { useReceiveFlowState } from './useReceiveFlowState';
+
+describe('useReceiveFlowState', () => {
+  it('rejects repeated confirmation attempts until the active flow resets', () => {
+    const flow = useReceiveFlowState();
+
+    expect(flow.startConfirmation()).toBe(true);
+    expect(flow.state.value).toBe('confirming');
+    expect(flow.isBusy.value).toBe(true);
+    expect(flow.startConfirmation()).toBe(false);
+
+    flow.reset();
+
+    expect(flow.state.value).toBe('idle');
+    expect(flow.isBusy.value).toBe(false);
+    expect(flow.startConfirmation()).toBe(true);
+  });
+
+  it('only starts submission from an active confirmation flow', () => {
+    const flow = useReceiveFlowState();
+
+    expect(flow.startSubmission()).toBe(false);
+    expect(flow.state.value).toBe('idle');
+
+    flow.startConfirmation();
+
+    expect(flow.startSubmission()).toBe(true);
+    expect(flow.state.value).toBe('submitting');
+    expect(flow.startSubmission()).toBe(false);
+    expect(flow.startConfirmation()).toBe(false);
+  });
+});

--- a/src/composables/useReceiveFlowState.ts
+++ b/src/composables/useReceiveFlowState.ts
@@ -1,0 +1,38 @@
+import { computed, readonly, ref } from 'vue';
+
+export type ReceiveFlowState = 'idle' | 'confirming' | 'submitting';
+
+export const useReceiveFlowState = () => {
+  const state = ref<ReceiveFlowState>('idle');
+  const isBusy = computed(() => state.value !== 'idle');
+
+  const startConfirmation = () => {
+    if (state.value !== 'idle') {
+      return false;
+    }
+
+    state.value = 'confirming';
+    return true;
+  };
+
+  const startSubmission = () => {
+    if (state.value !== 'confirming') {
+      return false;
+    }
+
+    state.value = 'submitting';
+    return true;
+  };
+
+  const reset = () => {
+    state.value = 'idle';
+  };
+
+  return {
+    state: readonly(state),
+    isBusy,
+    startConfirmation,
+    startSubmission,
+    reset
+  };
+};

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -373,7 +373,7 @@ import ReceivingInstructions from '@/components/ReceivingInstructions.vue';
 import ReceiveTransferOrder from '@/components/ReceiveTransferOrder.vue';
 import router from '@/router';
 import { useReceiveFlowState } from '@/composables/useReceiveFlowState';
-import { runTransferOrderDetailReceiveWorkflow, type TransferOrderReceiveMode } from '@/views/transferOrderDetailReceiveWorkflow';
+import { runTransferOrderDetailReceiveWorkflow } from '@/views/transferOrderDetailReceiveWorkflow';
 
 const transferOrderStore = useTransferOrderStore();
 const product = useProduct();
@@ -740,15 +740,13 @@ const confirmReceiveAndClose = async () => {
   return Boolean(value?.data?.updateItems);
 };
 
-const runReceiveWorkflow = (mode: TransferOrderReceiveMode, confirm: () => Promise<boolean>) => {
+const runReceiveWorkflow = (isClosingTO: boolean, confirm: () => Promise<boolean>) => {
   return runTransferOrderDetailReceiveWorkflow({
-    mode,
     startConfirmation: startReceiveConfirmation,
     startSubmission: startReceiveSubmission,
     reset: resetReceiveFlow,
     confirm,
-    submit: () => receiveTransferOrder(mode === 'complete'),
-    refresh: refreshTransferOrderDetail,
+    submit: () => receiveTransferOrder(isClosingTO),
     navigate: async () => {
       await router.push('/transfer-orders');
     },
@@ -761,8 +759,8 @@ const runReceiveWorkflow = (mode: TransferOrderReceiveMode, confirm: () => Promi
   });
 };
 
-const receiveTO = () => runReceiveWorkflow('save-progress', confirmSaveProgress);
-const receiveAndCloseTO = () => runReceiveWorkflow('complete', confirmReceiveAndClose);
+const receiveTO = () => runReceiveWorkflow(false, confirmSaveProgress);
+const receiveAndCloseTO = () => runReceiveWorkflow(true, confirmReceiveAndClose);
 
 const receiveTransferOrder = async (isClosingTO = false) => {
   let eligibleItems: any = [];

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -373,6 +373,7 @@ import ReceivingInstructions from '@/components/ReceivingInstructions.vue';
 import ReceiveTransferOrder from '@/components/ReceiveTransferOrder.vue';
 import router from '@/router';
 import { useReceiveFlowState } from '@/composables/useReceiveFlowState';
+import { runTransferOrderDetailReceiveWorkflow, type TransferOrderReceiveMode } from '@/views/transferOrderDetailReceiveWorkflow';
 
 const transferOrderStore = useTransferOrderStore();
 const product = useProduct();
@@ -651,61 +652,43 @@ const isAnyItemOverReceived = () => {
   return [...openItems.value, ...openItemsTemp.value].some((item: any) => ((Number(item.totalReceivedQuantity) || 0) + (Number(item.quantityAccepted) || 0)) > getItemQty(item));
 };
 
-const receiveTO = async () => {
-  if (!startReceiveConfirmation()) {
-    return;
-  }
-
+const confirmSaveProgress = async () => {
   dismissToast();
-  try {
-    if (!isEligibleForCreatingShipment() || !userStore.hasPermission('RECEIVING_ADMIN')) {
-      await receivingAlert();
-      return;
-    }
-
-    let shouldReceive = false;
-    if (!isAnyItemOverReceived()) {
-      const alert = await alertController.create({
-        header: translate("Save progress and receive more later"),
-        message: translate("Your receiving progress will be saved and will be added to your inventory. Come back to this transfer order and finish receiving later. Fully received items auto close.", { space: "<br /><br />", units: getReceivedUnits() }),
-        buttons: [{
-          text: translate('Cancel'),
-          role: 'cancel'
-        },
-        {
-          text: translate('Proceed'),
-          role: 'proceed'
-        }]
-      });
-      await alert.present();
-      const result = await alert.onDidDismiss();
-      shouldReceive = result.role === 'proceed';
-    } else {
-      const modal = await modalController.create({
-        component: ReceiveTransferOrder,
-        componentProps: {
-          items: filteredItems.value,
-          receivedUnitsFraction: getReceivedUnits()
-        }
-      });
-
-      await modal.present();
-      const value = await modal.onDidDismiss();
-      filteredItems.value.forEach((item: any) => item.isChecked = false);
-      shouldReceive = Boolean(value?.data?.updateItems);
-    }
-
-    if (shouldReceive && startReceiveSubmission()) {
-      emitter.emit("presentLoader", { message: translate("Receiving in progress..."), backdropDismiss: false });
-      try {
-        await receiveTransferOrder();
-      } finally {
-        emitter.emit("dismissLoader");
-      }
-    }
-  } finally {
-    resetReceiveFlow();
+  if (!isEligibleForCreatingShipment() || !userStore.hasPermission('RECEIVING_ADMIN')) {
+    await receivingAlert();
+    return false;
   }
+
+  if (!isAnyItemOverReceived()) {
+    const alert = await alertController.create({
+      header: translate("Save progress and receive more later"),
+      message: translate("Your receiving progress will be saved and will be added to your inventory. Come back to this transfer order and finish receiving later. Fully received items auto close.", { space: "<br /><br />", units: getReceivedUnits() }),
+      buttons: [{
+        text: translate('Cancel'),
+        role: 'cancel'
+      },
+      {
+        text: translate('Proceed'),
+        role: 'proceed'
+      }]
+    });
+    await alert.present();
+    const result = await alert.onDidDismiss();
+    return result.role === 'proceed';
+  }
+
+  const modal = await modalController.create({
+    component: ReceiveTransferOrder,
+    componentProps: {
+      items: filteredItems.value,
+      receivedUnitsFraction: getReceivedUnits()
+    }
+  });
+
+  await modal.present();
+  const value = await modal.onDidDismiss();
+  filteredItems.value.forEach((item: any) => item.isChecked = false);
+  return Boolean(value?.data?.updateItems);
 };
 
 const showAllOpenItems = () => {
@@ -713,67 +696,73 @@ const showAllOpenItems = () => {
   openItemsTemp.value = [];
 };
 
-const receiveAndCloseTO = async () => {
-  if (!startReceiveConfirmation()) {
-    return;
-  }
-
+const confirmReceiveAndClose = async () => {
   dismissToast();
-  try {
-    if (!isEligibleForCreatingShipment(true) || !userStore.hasPermission('RECEIVING_ADMIN')) {
-      await receivingAlert();
-      return;
-    }
-
-    const itemsReceived = [] as any;
-    const itemsNotReceived = [] as any;
-    openItems.value.map((item: any) => {
-      if (!(item.quantityAccepted && item.quantityAccepted >= 0)) {
-        itemsNotReceived.push(item);
-      } else {
-        itemsReceived.push(item);
-      }
-    });
-    if (itemsNotReceived.length) {
-      openItemsTemp.value = itemsReceived;
-      openItems.value = itemsNotReceived;
-      document.querySelector("ion-segment")?.scrollIntoView();
-      return;
-    }
-
-    const items = [...openItems.value, ...openItemsTemp.value];
-    const isAnyItemUnderReceived = items.some((item: any) => ((Number(item.totalReceivedQuantity) || 0) + (Number(item.quantityAccepted) || 0)) != getItemQty(item));
-    let shouldReceive = false;
-    if (!isAnyItemOverReceived() && !isAnyItemUnderReceived) {
-      shouldReceive = await confirmComplete();
-    } else {
-      const modal = await modalController.create({
-        component: ReceiveTransferOrder,
-        componentProps: {
-          closeTO: true,
-          items: filteredItems.value,
-          receivedUnitsFraction: getReceivedUnits()
-        }
-      });
-
-      await modal.present();
-      const value = await modal.onDidDismiss();
-      filteredItems.value.forEach((item: any) => item.isChecked = false);
-      shouldReceive = Boolean(value?.data?.updateItems);
-    }
-
-    if (shouldReceive && startReceiveSubmission()) {
-      emitter.emit("presentLoader", { message: translate("Receiving in progress..."), backdropDismiss: false });
-      try {
-        await receiveTransferOrder(true);
-      } finally {
-        emitter.emit("dismissLoader");
-      }
-    }
-  } finally {
-    resetReceiveFlow();
+  if (!isEligibleForCreatingShipment(true) || !userStore.hasPermission('RECEIVING_ADMIN')) {
+    await receivingAlert();
+    return false;
   }
+
+  const itemsReceived = [] as any;
+  const itemsNotReceived = [] as any;
+  openItems.value.map((item: any) => {
+    if (!(item.quantityAccepted && item.quantityAccepted >= 0)) {
+      itemsNotReceived.push(item);
+    } else {
+      itemsReceived.push(item);
+    }
+  });
+  if (itemsNotReceived.length) {
+    openItemsTemp.value = itemsReceived;
+    openItems.value = itemsNotReceived;
+    document.querySelector("ion-segment")?.scrollIntoView();
+    return false;
+  }
+
+  const items = [...openItems.value, ...openItemsTemp.value];
+  const isAnyItemUnderReceived = items.some((item: any) => ((Number(item.totalReceivedQuantity) || 0) + (Number(item.quantityAccepted) || 0)) != getItemQty(item));
+  if (!isAnyItemOverReceived() && !isAnyItemUnderReceived) {
+    return confirmComplete();
+  }
+
+  const modal = await modalController.create({
+    component: ReceiveTransferOrder,
+    componentProps: {
+      closeTO: true,
+      items: filteredItems.value,
+      receivedUnitsFraction: getReceivedUnits()
+    }
+  });
+
+  await modal.present();
+  const value = await modal.onDidDismiss();
+  filteredItems.value.forEach((item: any) => item.isChecked = false);
+  return Boolean(value?.data?.updateItems);
 };
+
+const runReceiveWorkflow = (mode: TransferOrderReceiveMode, confirm: () => Promise<boolean>) => {
+  return runTransferOrderDetailReceiveWorkflow({
+    mode,
+    startConfirmation: startReceiveConfirmation,
+    startSubmission: startReceiveSubmission,
+    reset: resetReceiveFlow,
+    confirm,
+    submit: () => receiveTransferOrder(mode === 'complete'),
+    refresh: refreshTransferOrderDetail,
+    navigate: async () => {
+      await router.push('/transfer-orders');
+    },
+    onSubmissionStart: () => {
+      emitter.emit("presentLoader", { message: translate("Receiving in progress..."), backdropDismiss: false });
+    },
+    onSubmissionEnd: () => {
+      emitter.emit("dismissLoader");
+    }
+  });
+};
+
+const receiveTO = () => runReceiveWorkflow('save-progress', confirmSaveProgress);
+const receiveAndCloseTO = () => runReceiveWorkflow('complete', confirmReceiveAndClose);
 
 const receiveTransferOrder = async (isClosingTO = false) => {
   let eligibleItems: any = [];
@@ -811,11 +800,12 @@ const receiveTransferOrder = async (isClosingTO = false) => {
     const resp = await transferOrderStore.receiveTransferOrder(order.value.orderId, payload);
     if (!commonUtil.hasError(resp)) {
       commonUtil.showToast(translate("Transfer order received successfully", { orderId: order.value.orderId }));
-      router.push('/transfer-orders');
+      return true;
     }
   } catch (error) {
     commonUtil.showToast(translate("Error in receiving transfer order", { orderId: order.value.orderId }));
   }
+  return false;
 };
 
 const isEligibleForCreatingShipment = (isClosingTO = false) => {
@@ -860,6 +850,37 @@ const observeProductVisibility = () => {
   });
 };
 
+const refreshTransferOrderDetail = async () => {
+  const orderId = router.currentRoute.value.params.slug;
+
+  transferOrderStore.clearTransferOrderDetail();
+  filteredItems.value = [];
+  completedItems.value = [];
+  openItems.value = [];
+  openItemsTemp.value = [];
+  fulfilledItems.value = 0;
+  productQoh.value = {};
+
+  await transferOrderStore.fetchMisShippedItems({ orderId });
+  await transferOrderStore.fetchTransferOrderDetail({ orderId });
+  if (order.value.orderId) {
+    await transferOrderStore.fetchTOHistory({
+      payload: {
+        orderId: order.value.orderId,
+        orderByField: "-datetimeReceived"
+      }
+    });
+  }
+
+  showCompletedItems.value = isTOReceived();
+  filteredItems.value = order.value.items ? [...order.value.items] : [];
+  completedItems.value = filteredItems.value.filter((item: any) => item.statusId === 'ITEM_COMPLETED');
+  openItems.value = filteredItems.value.filter((item: any) => !['ITEM_COMPLETED', 'ITEM_REJECTED', 'ITEM_CANCELLED'].includes(item.statusId));
+  fulfilledItems.value = filteredItems.value.filter((item: any) => item.totalIssuedQuantity)?.length;
+
+  observeProductVisibility();
+};
+
 const fetchQuantityOnHand = async (productId: any) => {
   productQoh.value[productId] = await product.getInventoryAvailableByFacility(productId);
 };
@@ -877,27 +898,11 @@ const openTOReceivingInstructions = async () => {
 
 onIonViewWillEnter(async () => {
   emitter.emit('presentLoader', { backdropDismiss: false, message: translate("Fetching details...") });
-  transferOrderStore.clearTransferOrderDetail();
-
-  await transferOrderStore.fetchMisShippedItems({ orderId: router.currentRoute.value.params.slug });
-  await transferOrderStore.fetchTransferOrderDetail({ orderId: router.currentRoute.value.params.slug });
-  await transferOrderStore.fetchTOHistory({
-    payload: {
-      orderId: order.value.orderId,
-      orderByField: "-datetimeReceived"
-    }
-  });
-  if (isTOReceived()) {
-    showCompletedItems.value = true;
+  try {
+    await refreshTransferOrderDetail();
+  } finally {
+    emitter.emit('dismissLoader');
   }
-
-  filteredItems.value = order.value.items ? [...order.value.items] : [];
-  completedItems.value = filteredItems.value.filter((item: any) => item.statusId === 'ITEM_COMPLETED');
-  openItems.value = filteredItems.value.filter((item: any) => !['ITEM_COMPLETED', 'ITEM_REJECTED', 'ITEM_CANCELLED'].includes(item.statusId));
-  fulfilledItems.value = filteredItems.value.filter((item: any) => item.totalIssuedQuantity)?.length;
-
-  observeProductVisibility();
-  emitter.emit('dismissLoader');
 });
 
 onIonViewDidLeave(() => {

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -848,37 +848,6 @@ const observeProductVisibility = () => {
   });
 };
 
-const refreshTransferOrderDetail = async () => {
-  const orderId = router.currentRoute.value.params.slug;
-
-  transferOrderStore.clearTransferOrderDetail();
-  filteredItems.value = [];
-  completedItems.value = [];
-  openItems.value = [];
-  openItemsTemp.value = [];
-  fulfilledItems.value = 0;
-  productQoh.value = {};
-
-  await transferOrderStore.fetchMisShippedItems({ orderId });
-  await transferOrderStore.fetchTransferOrderDetail({ orderId });
-  if (order.value.orderId) {
-    await transferOrderStore.fetchTOHistory({
-      payload: {
-        orderId: order.value.orderId,
-        orderByField: "-datetimeReceived"
-      }
-    });
-  }
-
-  showCompletedItems.value = isTOReceived();
-  filteredItems.value = order.value.items ? [...order.value.items] : [];
-  completedItems.value = filteredItems.value.filter((item: any) => item.statusId === 'ITEM_COMPLETED');
-  openItems.value = filteredItems.value.filter((item: any) => !['ITEM_COMPLETED', 'ITEM_REJECTED', 'ITEM_CANCELLED'].includes(item.statusId));
-  fulfilledItems.value = filteredItems.value.filter((item: any) => item.totalIssuedQuantity)?.length;
-
-  observeProductVisibility();
-};
-
 const fetchQuantityOnHand = async (productId: any) => {
   productQoh.value[productId] = await product.getInventoryAvailableByFacility(productId);
 };
@@ -896,11 +865,27 @@ const openTOReceivingInstructions = async () => {
 
 onIonViewWillEnter(async () => {
   emitter.emit('presentLoader', { backdropDismiss: false, message: translate("Fetching details...") });
-  try {
-    await refreshTransferOrderDetail();
-  } finally {
-    emitter.emit('dismissLoader');
+  transferOrderStore.clearTransferOrderDetail();
+
+  await transferOrderStore.fetchMisShippedItems({ orderId: router.currentRoute.value.params.slug });
+  await transferOrderStore.fetchTransferOrderDetail({ orderId: router.currentRoute.value.params.slug });
+  await transferOrderStore.fetchTOHistory({
+    payload: {
+      orderId: order.value.orderId,
+      orderByField: "-datetimeReceived"
+    }
+  });
+  if (isTOReceived()) {
+    showCompletedItems.value = true;
   }
+
+  filteredItems.value = order.value.items ? [...order.value.items] : [];
+  completedItems.value = filteredItems.value.filter((item: any) => item.statusId === 'ITEM_COMPLETED');
+  openItems.value = filteredItems.value.filter((item: any) => !['ITEM_COMPLETED', 'ITEM_REJECTED', 'ITEM_CANCELLED'].includes(item.statusId));
+  fulfilledItems.value = filteredItems.value.filter((item: any) => item.totalIssuedQuantity)?.length;
+
+  observeProductVisibility();
+  emitter.emit('dismissLoader');
 });
 
 onIonViewDidLeave(() => {

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -345,8 +345,8 @@
     <ion-footer data-testid="transfer-order-detail-page-footer" id="footer" ref="footer" v-if="!isTOReceived() && selectedSegment !== 'received'">
       <ion-toolbar>
         <ion-buttons slot="end">
-          <ion-button data-testid="transfer-order-detail-page-save-progress-btn" :disabled="!areAllItemsHaveQty" class="ion-margin-end" fill="outline" size="small" color="primary" @click="receiveTO">{{ translate("Save Progress") }}{{ ":" }} {{ getReceivedUnits() }}</ion-button>
-          <ion-button data-testid="transfer-order-detail-page-receive-complete-btn" :disabled="!areAllItemsHaveQty" fill="solid" size="small" color="primary" @click="receiveAndCloseTO">{{ translate("Receive and complete") }}</ion-button>
+          <ion-button data-testid="transfer-order-detail-page-save-progress-btn" :disabled="!areAllItemsHaveQty || isReceiveFlowBusy" class="ion-margin-end" fill="outline" size="small" color="primary" @click="receiveTO">{{ translate("Save Progress") }}{{ ":" }} {{ getReceivedUnits() }}</ion-button>
+          <ion-button data-testid="transfer-order-detail-page-receive-complete-btn" :disabled="!areAllItemsHaveQty || isReceiveFlowBusy" fill="solid" size="small" color="primary" @click="receiveAndCloseTO">{{ translate("Receive and complete") }}</ion-button>
         </ion-buttons>
       </ion-toolbar>
     </ion-footer>
@@ -372,12 +372,19 @@ import { DateTime } from 'luxon';
 import ReceivingInstructions from '@/components/ReceivingInstructions.vue';
 import ReceiveTransferOrder from '@/components/ReceiveTransferOrder.vue';
 import router from '@/router';
+import { useReceiveFlowState } from '@/composables/useReceiveFlowState';
 
 const transferOrderStore = useTransferOrderStore();
 const product = useProduct();
 const utilStore = useUtilStore();
 const userStore = useUserStore();
 const productStore = useProductStore();
+const {
+  isBusy: isReceiveFlowBusy,
+  startConfirmation: startReceiveConfirmation,
+  startSubmission: startReceiveSubmission,
+  reset: resetReceiveFlow
+} = useReceiveFlowState();
 
 const queryString = ref('');
 const showCompletedItems = ref(false);
@@ -618,7 +625,8 @@ const receivingAlert = async () => {
     }]
   });
 
-  return alert.present();
+  await alert.present();
+  await alert.onDidDismiss();
 };
 
 const confirmComplete = async () => {
@@ -631,19 +639,12 @@ const confirmComplete = async () => {
     },
     {
       text: translate("Proceed"),
-      role: "proceed",
-      handler: async () => {
-        alert.dismiss();
-        emitter.emit("presentLoader", { message: translate("Receiving in progress..."), backdropDismiss: false });
-        try {
-          await receiveTransferOrder(true);
-        } finally {
-          emitter.emit("dismissLoader");
-        }
-      }
+      role: "proceed"
     }]
   });
-  return alert.present();
+  await alert.present();
+  const result = await alert.onDidDismiss();
+  return result.role === 'proceed';
 };
 
 const isAnyItemOverReceived = () => {
@@ -651,56 +652,59 @@ const isAnyItemOverReceived = () => {
 };
 
 const receiveTO = async () => {
-  dismissToast();
-  if (!isEligibleForCreatingShipment() || !userStore.hasPermission('RECEIVING_ADMIN')) {
-    return await receivingAlert();
+  if (!startReceiveConfirmation()) {
+    return;
   }
 
-  if (!isAnyItemOverReceived()) {
-    const alert = await alertController.create({
-      header: translate("Save progress and receive more later"),
-      message: translate("Your receiving progress will be saved and will be added to your inventory. Come back to this transfer order and finish receiving later. Fully received items auto close.", { space: "<br /><br />", units: getReceivedUnits() }),
-      buttons: [{
-        text: translate('Cancel'),
-        role: 'cancel'
-      },
-      {
-        text: translate('Proceed'),
-        role: 'proceed',
-        handler: async () => {
-          alert.dismiss();
-          emitter.emit("presentLoader", { message: translate("Receiving in progress..."), backdropDismiss: false });
-          try {
-            await receiveTransferOrder();
-          } finally {
-            emitter.emit("dismissLoader");
-          }
-        }
-      }]
-    });
-    return alert.present();
-  } else {
-    const modal = await modalController.create({
-      component: ReceiveTransferOrder,
-      componentProps: {
-        items: filteredItems.value,
-        receivedUnitsFraction: getReceivedUnits()
-      }
-    });
+  dismissToast();
+  try {
+    if (!isEligibleForCreatingShipment() || !userStore.hasPermission('RECEIVING_ADMIN')) {
+      await receivingAlert();
+      return;
+    }
 
-    modal.onDidDismiss().then(async (value: any) => {
+    let shouldReceive = false;
+    if (!isAnyItemOverReceived()) {
+      const alert = await alertController.create({
+        header: translate("Save progress and receive more later"),
+        message: translate("Your receiving progress will be saved and will be added to your inventory. Come back to this transfer order and finish receiving later. Fully received items auto close.", { space: "<br /><br />", units: getReceivedUnits() }),
+        buttons: [{
+          text: translate('Cancel'),
+          role: 'cancel'
+        },
+        {
+          text: translate('Proceed'),
+          role: 'proceed'
+        }]
+      });
+      await alert.present();
+      const result = await alert.onDidDismiss();
+      shouldReceive = result.role === 'proceed';
+    } else {
+      const modal = await modalController.create({
+        component: ReceiveTransferOrder,
+        componentProps: {
+          items: filteredItems.value,
+          receivedUnitsFraction: getReceivedUnits()
+        }
+      });
+
+      await modal.present();
+      const value = await modal.onDidDismiss();
       filteredItems.value.forEach((item: any) => item.isChecked = false);
-      if (value?.data?.updateItems) {
-        emitter.emit("presentLoader", { message: translate("Receiving in progress..."), backdropDismiss: false });
-        try {
-          await receiveTransferOrder();
-        } finally {
-          emitter.emit("dismissLoader");
-        }
-      }
-    });
+      shouldReceive = Boolean(value?.data?.updateItems);
+    }
 
-    return modal.present();
+    if (shouldReceive && startReceiveSubmission()) {
+      emitter.emit("presentLoader", { message: translate("Receiving in progress..."), backdropDismiss: false });
+      try {
+        await receiveTransferOrder();
+      } finally {
+        emitter.emit("dismissLoader");
+      }
+    }
+  } finally {
+    resetReceiveFlow();
   }
 };
 
@@ -710,45 +714,55 @@ const showAllOpenItems = () => {
 };
 
 const receiveAndCloseTO = async () => {
-  dismissToast();
-  if (!isEligibleForCreatingShipment(true) || !userStore.hasPermission('RECEIVING_ADMIN')) {
-    return await receivingAlert();
-  }
-
-  const itemsReceived = [] as any;
-  const itemsNotReceived = [] as any;
-  openItems.value.map((item: any) => {
-    if (!(item.quantityAccepted && item.quantityAccepted >= 0)) {
-      itemsNotReceived.push(item);
-    } else {
-      itemsReceived.push(item);
-    }
-  });
-  if (itemsNotReceived.length) {
-    openItemsTemp.value = itemsReceived;
-    openItems.value = itemsNotReceived;
-    document.querySelector("ion-segment")?.scrollIntoView();
+  if (!startReceiveConfirmation()) {
     return;
   }
 
-  const items = [...openItems.value, ...openItemsTemp.value];
-  const isAnyItemUnderReceived = items.some((item: any) => ((Number(item.totalReceivedQuantity) || 0) + (Number(item.quantityAccepted) || 0)) != getItemQty(item));
-  if (!isAnyItemOverReceived() && !isAnyItemUnderReceived) {
-    return await confirmComplete();
-  }
-
-  const modal = await modalController.create({
-    component: ReceiveTransferOrder,
-    componentProps: {
-      closeTO: true,
-      items: filteredItems.value,
-      receivedUnitsFraction: getReceivedUnits()
+  dismissToast();
+  try {
+    if (!isEligibleForCreatingShipment(true) || !userStore.hasPermission('RECEIVING_ADMIN')) {
+      await receivingAlert();
+      return;
     }
-  });
 
-  modal.onDidDismiss().then(async (value: any) => {
-    filteredItems.value.forEach((item: any) => item.isChecked = false);
-    if (value?.data?.updateItems) {
+    const itemsReceived = [] as any;
+    const itemsNotReceived = [] as any;
+    openItems.value.map((item: any) => {
+      if (!(item.quantityAccepted && item.quantityAccepted >= 0)) {
+        itemsNotReceived.push(item);
+      } else {
+        itemsReceived.push(item);
+      }
+    });
+    if (itemsNotReceived.length) {
+      openItemsTemp.value = itemsReceived;
+      openItems.value = itemsNotReceived;
+      document.querySelector("ion-segment")?.scrollIntoView();
+      return;
+    }
+
+    const items = [...openItems.value, ...openItemsTemp.value];
+    const isAnyItemUnderReceived = items.some((item: any) => ((Number(item.totalReceivedQuantity) || 0) + (Number(item.quantityAccepted) || 0)) != getItemQty(item));
+    let shouldReceive = false;
+    if (!isAnyItemOverReceived() && !isAnyItemUnderReceived) {
+      shouldReceive = await confirmComplete();
+    } else {
+      const modal = await modalController.create({
+        component: ReceiveTransferOrder,
+        componentProps: {
+          closeTO: true,
+          items: filteredItems.value,
+          receivedUnitsFraction: getReceivedUnits()
+        }
+      });
+
+      await modal.present();
+      const value = await modal.onDidDismiss();
+      filteredItems.value.forEach((item: any) => item.isChecked = false);
+      shouldReceive = Boolean(value?.data?.updateItems);
+    }
+
+    if (shouldReceive && startReceiveSubmission()) {
       emitter.emit("presentLoader", { message: translate("Receiving in progress..."), backdropDismiss: false });
       try {
         await receiveTransferOrder(true);
@@ -756,9 +770,9 @@ const receiveAndCloseTO = async () => {
         emitter.emit("dismissLoader");
       }
     }
-  });
-
-  return modal.present();
+  } finally {
+    resetReceiveFlow();
+  }
 };
 
 const receiveTransferOrder = async (isClosingTO = false) => {

--- a/src/views/transferOrderDetailReceiveWorkflow.spec.ts
+++ b/src/views/transferOrderDetailReceiveWorkflow.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+import { useReceiveFlowState } from '@/composables/useReceiveFlowState';
+import { runTransferOrderDetailReceiveWorkflow, type TransferOrderReceiveMode } from './transferOrderDetailReceiveWorkflow';
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolver) => {
+    resolve = resolver;
+  });
+  return { promise, resolve };
+};
+
+const createWorkflow = (mode: TransferOrderReceiveMode) => {
+  const flow = useReceiveFlowState();
+  const presentConfirmationOverlay = vi.fn(async () => true);
+  const receiveTransferOrder = vi.fn(async () => true);
+  const refresh = vi.fn(async () => undefined);
+  const navigate = vi.fn(async () => undefined);
+
+  const run = () => runTransferOrderDetailReceiveWorkflow({
+    mode,
+    startConfirmation: flow.startConfirmation,
+    startSubmission: flow.startSubmission,
+    reset: flow.reset,
+    confirm: presentConfirmationOverlay,
+    submit: receiveTransferOrder,
+    refresh,
+    navigate
+  });
+
+  return { flow, presentConfirmationOverlay, receiveTransferOrder, refresh, navigate, run };
+};
+
+describe('TransferOrderDetail receive workflow', () => {
+  it('allows one overlay and one receipt submission for rapid concurrent Save Progress actions', async () => {
+    const workflow = createWorkflow('save-progress');
+    const confirmation = deferred<boolean>();
+    workflow.presentConfirmationOverlay.mockImplementation(() => confirmation.promise);
+
+    const firstRun = workflow.run();
+    const secondRun = workflow.run();
+
+    expect(workflow.presentConfirmationOverlay).toHaveBeenCalledTimes(1);
+    expect(await secondRun).toBe(false);
+
+    confirmation.resolve(true);
+    expect(await firstRun).toBe(true);
+    expect(workflow.receiveTransferOrder).toHaveBeenCalledTimes(1);
+    expect(workflow.refresh).toHaveBeenCalledTimes(1);
+    expect(workflow.navigate).not.toHaveBeenCalled();
+  });
+
+  it('keeps the completion submission locked until navigation finishes', async () => {
+    const workflow = createWorkflow('complete');
+    const navigation = deferred<void>();
+    workflow.navigate.mockImplementation(() => navigation.promise);
+
+    const firstRun = workflow.run();
+    await vi.waitFor(() => expect(workflow.navigate).toHaveBeenCalledTimes(1));
+
+    expect(workflow.flow.state.value).toBe('submitting');
+    expect(await workflow.run()).toBe(false);
+    expect(workflow.presentConfirmationOverlay).toHaveBeenCalledTimes(1);
+    expect(workflow.receiveTransferOrder).toHaveBeenCalledTimes(1);
+    expect(workflow.refresh).not.toHaveBeenCalled();
+
+    navigation.resolve();
+    expect(await firstRun).toBe(true);
+    expect(workflow.flow.state.value).toBe('idle');
+  });
+
+  it('releases the lock when confirmation is cancelled', async () => {
+    const workflow = createWorkflow('save-progress');
+    workflow.presentConfirmationOverlay.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    expect(await workflow.run()).toBe(false);
+    expect(workflow.flow.state.value).toBe('idle');
+    expect(await workflow.run()).toBe(true);
+    expect(workflow.receiveTransferOrder).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the lock when receipt submission fails', async () => {
+    const workflow = createWorkflow('save-progress');
+    workflow.receiveTransferOrder.mockResolvedValue(false);
+
+    expect(await workflow.run()).toBe(false);
+    expect(workflow.flow.state.value).toBe('idle');
+    expect(workflow.refresh).not.toHaveBeenCalled();
+    expect(workflow.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/views/transferOrderDetailReceiveWorkflow.spec.ts
+++ b/src/views/transferOrderDetailReceiveWorkflow.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { useReceiveFlowState } from '@/composables/useReceiveFlowState';
-import { runTransferOrderDetailReceiveWorkflow, type TransferOrderReceiveMode } from './transferOrderDetailReceiveWorkflow';
+import { runTransferOrderDetailReceiveWorkflow } from './transferOrderDetailReceiveWorkflow';
 
 const deferred = <T>() => {
   let resolve!: (value: T) => void;
@@ -10,30 +10,27 @@ const deferred = <T>() => {
   return { promise, resolve };
 };
 
-const createWorkflow = (mode: TransferOrderReceiveMode) => {
+const createWorkflow = () => {
   const flow = useReceiveFlowState();
   const presentConfirmationOverlay = vi.fn(async () => true);
   const receiveTransferOrder = vi.fn(async () => true);
-  const refresh = vi.fn(async () => undefined);
   const navigate = vi.fn(async () => undefined);
 
   const run = () => runTransferOrderDetailReceiveWorkflow({
-    mode,
     startConfirmation: flow.startConfirmation,
     startSubmission: flow.startSubmission,
     reset: flow.reset,
     confirm: presentConfirmationOverlay,
     submit: receiveTransferOrder,
-    refresh,
     navigate
   });
 
-  return { flow, presentConfirmationOverlay, receiveTransferOrder, refresh, navigate, run };
+  return { flow, presentConfirmationOverlay, receiveTransferOrder, navigate, run };
 };
 
 describe('TransferOrderDetail receive workflow', () => {
   it('allows one overlay and one receipt submission for rapid concurrent Save Progress actions', async () => {
-    const workflow = createWorkflow('save-progress');
+    const workflow = createWorkflow();
     const confirmation = deferred<boolean>();
     workflow.presentConfirmationOverlay.mockImplementation(() => confirmation.promise);
 
@@ -46,12 +43,11 @@ describe('TransferOrderDetail receive workflow', () => {
     confirmation.resolve(true);
     expect(await firstRun).toBe(true);
     expect(workflow.receiveTransferOrder).toHaveBeenCalledTimes(1);
-    expect(workflow.refresh).toHaveBeenCalledTimes(1);
-    expect(workflow.navigate).not.toHaveBeenCalled();
+    expect(workflow.navigate).toHaveBeenCalledTimes(1);
   });
 
   it('keeps the completion submission locked until navigation finishes', async () => {
-    const workflow = createWorkflow('complete');
+    const workflow = createWorkflow();
     const navigation = deferred<void>();
     workflow.navigate.mockImplementation(() => navigation.promise);
 
@@ -62,7 +58,6 @@ describe('TransferOrderDetail receive workflow', () => {
     expect(await workflow.run()).toBe(false);
     expect(workflow.presentConfirmationOverlay).toHaveBeenCalledTimes(1);
     expect(workflow.receiveTransferOrder).toHaveBeenCalledTimes(1);
-    expect(workflow.refresh).not.toHaveBeenCalled();
 
     navigation.resolve();
     expect(await firstRun).toBe(true);
@@ -70,7 +65,7 @@ describe('TransferOrderDetail receive workflow', () => {
   });
 
   it('releases the lock when confirmation is cancelled', async () => {
-    const workflow = createWorkflow('save-progress');
+    const workflow = createWorkflow();
     workflow.presentConfirmationOverlay.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
 
     expect(await workflow.run()).toBe(false);
@@ -80,12 +75,11 @@ describe('TransferOrderDetail receive workflow', () => {
   });
 
   it('releases the lock when receipt submission fails', async () => {
-    const workflow = createWorkflow('save-progress');
+    const workflow = createWorkflow();
     workflow.receiveTransferOrder.mockResolvedValue(false);
 
     expect(await workflow.run()).toBe(false);
     expect(workflow.flow.state.value).toBe('idle');
-    expect(workflow.refresh).not.toHaveBeenCalled();
     expect(workflow.navigate).not.toHaveBeenCalled();
   });
 });

--- a/src/views/transferOrderDetailReceiveWorkflow.ts
+++ b/src/views/transferOrderDetailReceiveWorkflow.ts
@@ -1,0 +1,56 @@
+export type TransferOrderReceiveMode = 'save-progress' | 'complete';
+
+interface TransferOrderDetailReceiveWorkflowOptions {
+  mode: TransferOrderReceiveMode;
+  startConfirmation: () => boolean;
+  startSubmission: () => boolean;
+  reset: () => void;
+  confirm: () => Promise<boolean>;
+  submit: () => Promise<boolean>;
+  refresh: () => Promise<void>;
+  navigate: () => Promise<void>;
+  onSubmissionStart?: () => void;
+  onSubmissionEnd?: () => void;
+}
+
+export const runTransferOrderDetailReceiveWorkflow = async ({
+  mode,
+  startConfirmation,
+  startSubmission,
+  reset,
+  confirm,
+  submit,
+  refresh,
+  navigate,
+  onSubmissionStart,
+  onSubmissionEnd
+}: TransferOrderDetailReceiveWorkflowOptions) => {
+  if (!startConfirmation()) {
+    return false;
+  }
+
+  try {
+    if (!await confirm() || !startSubmission()) {
+      return false;
+    }
+
+    onSubmissionStart?.();
+    try {
+      if (!await submit()) {
+        return false;
+      }
+
+      if (mode === 'save-progress') {
+        await refresh();
+      } else {
+        await navigate();
+      }
+
+      return true;
+    } finally {
+      onSubmissionEnd?.();
+    }
+  } finally {
+    reset();
+  }
+};

--- a/src/views/transferOrderDetailReceiveWorkflow.ts
+++ b/src/views/transferOrderDetailReceiveWorkflow.ts
@@ -1,26 +1,20 @@
-export type TransferOrderReceiveMode = 'save-progress' | 'complete';
-
 interface TransferOrderDetailReceiveWorkflowOptions {
-  mode: TransferOrderReceiveMode;
   startConfirmation: () => boolean;
   startSubmission: () => boolean;
   reset: () => void;
   confirm: () => Promise<boolean>;
   submit: () => Promise<boolean>;
-  refresh: () => Promise<void>;
   navigate: () => Promise<void>;
   onSubmissionStart?: () => void;
   onSubmissionEnd?: () => void;
 }
 
 export const runTransferOrderDetailReceiveWorkflow = async ({
-  mode,
   startConfirmation,
   startSubmission,
   reset,
   confirm,
   submit,
-  refresh,
   navigate,
   onSubmissionStart,
   onSubmissionEnd
@@ -40,11 +34,7 @@ export const runTransferOrderDetailReceiveWorkflow = async ({
         return false;
       }
 
-      if (mode === 'save-progress') {
-        await refresh();
-      } else {
-        await navigate();
-      }
+      await navigate();
 
       return true;
     } finally {


### PR DESCRIPTION
## Business summary

Prevents rapid repeated receiving actions from opening stacked confirmations and submitting the same transfer order receipt more than once. This protects inventory accuracy while keeping the current receiving experience unchanged.

Closes #686.

## Root cause

The Transfer Order Detail actions remained re-entrant while Ionic asynchronously created and presented an alert or modal. Each click created an independent overlay with its own dismissal callback, so stacked confirmations could each submit the same receipt payload.

The issue is visible in the linked Jam recording: https://jam.dev/c/cf9ff2d6-1f60-4727-90f9-333ef9bae21a

## What changed

- Added a scoped receiving state machine with `idle`, `confirming`, and `submitting` states.
- Synchronously rejects repeated Save Progress or Receive and complete actions once a receiving flow starts.
- Keeps both footer actions disabled through the complete confirmation and submission lifecycle.
- Awaits Ionic overlay dismissal before deciding whether to submit, replacing detached asynchronous callbacks.
- Resets the state in `finally` for cancel, success, and failure paths.
- Added focused unit coverage for re-entry rejection and valid state transitions.

A global app-wide overlay coordinator remains intentionally out of scope for this fix.

## Validation

- `pnpm --filter receiving exec vitest run` — 2 tests passed.
- `pnpm --filter receiving build` — passed.
- `git diff --check` — passed.
- `pnpm --filter receiving exec vue-tsc --noEmit` — currently reports existing repository-wide Pinia/store typing errors unrelated to this change.
