### PR TITLE
Improved: receiveAll to update the tapped item directly (port of #673)

### DIFF
--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -387,7 +387,7 @@ const isEligibileForCreatingShipment = () => {
 
 const receiveAll = (item: any) => {
   const qtyAlreadyAccepted = getPOItemAccepted.value(item.productId)
-  item.quantityAccepted = item.quantity - qtyAlreadyAccepted;
+  item.quantityAccepted = Math.max(item.quantity - qtyAlreadyAccepted, 0);
 };
 
 onIonViewWillEnter(() => {

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -387,13 +387,7 @@ const isEligibileForCreatingShipment = () => {
 
 const receiveAll = (item: any) => {
   const qtyAlreadyAccepted = getPOItemAccepted.value(item.productId)
-  order.value.items.find((ele: any) => {
-    if (ele.productId == item.productId) {
-      ele.quantityAccepted = ele.quantity - qtyAlreadyAccepted;
-      ele.progress = ele.quantityAccepted / ele.quantity;
-      return true;
-    }
-  })
+  item.quantityAccepted = item.quantity - qtyAlreadyAccepted;
 };
 
 onIonViewWillEnter(() => {

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -210,11 +210,7 @@ const isEligibleForReceivingReturns = () => {
 };
 
 const receiveAll = (item: any) => {
-  const ele = current.value.items.find((ele: any) => ele.itemSeqId == item.itemSeqId);
-  if (ele) {
-    ele.quantityAccepted = ele.returnQuantity;
-    ele.progress = ele.quantityAccepted / ele.returnQuantity;
-  }
+  item.quantityAccepted = item.returnQuantity;
 };
 
 const updateProductCount = async (payload?: any) => {

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -812,7 +812,6 @@ const receiveAll = (item: any) => {
   const qtyAlreadyAccepted = Number(item.totalReceivedQuantity) || 0;
   const qty = isReceivingByFulfillment.value ? item.totalIssuedQuantity : item.quantity;
   item.quantityAccepted = Math.max(qty - qtyAlreadyAccepted, 0);
-  item.progress = item.quantityAccepted / qty;
 };
 
 const isTOReceived = () => order.value.statusId === "ORDER_COMPLETED";


### PR DESCRIPTION
Closes #703

### 💡 What:
Ports the `receiveAll` optimization from #673 (auto-closed when its base branch `receiving-refactored` was deleted after merging to main via #684) onto current `main`, adapted for the refactored code:

- **PurchaseOrderDetail.vue** — removed the `order.items.find()` scan and assign `item.quantityAccepted` directly on the tapped item.
- **ReturnDetails.vue** — removed the `current.items.find()` scan; adapted to the refactored field (`returnQuantity` instead of the pre-refactor `quantityOrdered`).
- **TransferOrderDetail.vue** — already used direct mutation (successor of the ShipmentDetails.vue change in #673); removed only the dead `item.progress` write for consistency.

### 🎯 Why:
- `receiveAll` already receives the item reference from the template's `v-for`, so the `.find()` re-scan is a redundant O(N) lookup; direct assignment is O(1) and triggers the same Vue reactivity (`pendingItems`/`completedItems` are filter/sort computeds that preserve object references).
- The `item.progress` assignments are dead code: nothing reads them — all progress bars bind to the `getRcvdToOrderedFraction(item)` / `getRcvdToOrdrdFraction(item)` helpers. This matches the gemini-code-assist review feedback on #673.
- In PurchaseOrderDetail the `.find()` matched by `productId`, so on a PO with duplicate product lines it could update the first matching row instead of the tapped one; mutating the tapped `item` avoids that.

### 📊 Verification:
- `grep` confirms no remaining `.progress` reads or writes in `src/`.
- `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
