### PR TITLE
Fix: Migrate product store settings API from dataDocumentView to REST resource (#708)

### DIFF
--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -112,7 +112,7 @@ export const useProductStore = defineStore('productStore', {
             shopifyLocationId,
             pageSize: 1
           })
-          if (locationFacilityId) {
+          if (locationFacilityId)  {
             // Here facility ids can be empty the logged in user is admin,
             // though we're syncing new embedded app users with store manager group this check is required,
             // push logged in facility id to avoid error in login.
@@ -458,7 +458,7 @@ export const useProductStore = defineStore('productStore', {
       try {
         const resp = await api({ url: "oms/shopifyShops/locations", method: "GET", params: payload }) as any;
         return Promise.resolve(resp.data[0]?.facilityId)
-      } catch (error) {
+      } catch(error) {
         return Promise.reject({ code: "error", message: "Failed to fetch location information", serverResponse: error })
       }
     },

--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -112,7 +112,7 @@ export const useProductStore = defineStore('productStore', {
             shopifyLocationId,
             pageSize: 1
           })
-          if (locationFacilityId)  {
+          if (locationFacilityId) {
             // Here facility ids can be empty the logged in user is admin,
             // though we're syncing new embedded app users with store manager group this check is required,
             // push logged in facility id to avoid error in login.
@@ -279,26 +279,22 @@ export const useProductStore = defineStore('productStore', {
       const productStoreSettings = {} as any
 
       if (productStoreId) {
-        const payload = {
-          productStoreId,
-          settingTypeEnumId: Object.keys(defaultProductStoreSettings),
-          settingTypeEnumId_op: "in",
-          pageIndex: 0,
-          pageSize: 50
-        }
         try {
           const resp = await api({
-            url: `/oms/dataDocumentView`,
-            method: "POST",
-            data: {
-              dataDocumentId: "ProductStoreSetting",
-              customParametersMap: payload
+            url: `/admin/productStores/${productStoreId}/settings`,
+            method: "GET",
+            params: {
+              settingTypeEnumId: Object.keys(defaultProductStoreSettings),
+              settingTypeEnumId_op: "in",
+              pageSize: 50
             }
           }) as any
 
-          resp?.data?.entityValueList?.forEach((productSetting: any) => {
-            productStoreSettings[productSetting.settingTypeEnumId] = productSetting.settingValue
-          })
+          if (!commonUtil.hasError(resp) && resp.data) {
+            resp.data.forEach((productSetting: any) => {
+              productStoreSettings[productSetting.settingTypeEnumId] = productSetting.settingValue
+            })
+          }
         } catch (error) {
           logger.error("Failed to fetch settings", error)
         }
@@ -462,7 +458,7 @@ export const useProductStore = defineStore('productStore', {
       try {
         const resp = await api({ url: "oms/shopifyShops/locations", method: "GET", params: payload }) as any;
         return Promise.resolve(resp.data[0]?.facilityId)
-      } catch(error) {
+      } catch (error) {
         return Promise.reject({ code: "error", message: "Failed to fetch location information", serverResponse: error })
       }
     },


### PR DESCRIPTION
## Description

Fixes a `400 Bad Request` error on the Receiving app Settings page when fetching product store settings.

Previously, the app requested product store settings using `POST /oms/dataDocumentView` with `dataDocumentId: "ProductStoreSetting"`. This request failed because `ProductStoreSetting` is not available as a DataDocument in the target OMS environment.

This change migrates the request to the Product Store Settings REST resource.

## Changes Made

- Updated `src/store/productStore.ts`
  - Replaced `POST /oms/dataDocumentView` with:
    ```
    GET /admin/productStores/{productStoreId}/settings
    ```
  - Updated the response handling to parse the REST API response.

## Related Issue

Closes #708

## Verification

- Verified the Receiving app Settings page loads successfully.
- Confirmed the request to:
  ```
  GET /admin/productStores/STORE/settings
  ```
  returns `200 OK`.
- Verified product store settings (for example, Product Identifier Preference, Force Scan, and Receive by Fulfillment) are loaded correctly.