### PR TITLE
Fixed: force scan setting when enabled still allows manual receiving by improving the setting enums those were wrongly configured

### DIFF
--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -188,7 +188,7 @@ const lastScannedId = ref('');
 const order = computed(() => orderStore.getCurrent);
 const getProduct = computed(() => product.getProduct);
 const getPOItemAccepted = computed(() => orderStore.getPOItemAccepted);
-const isForceScanEnabled = computed(() => productStore.isProductStoreSettingEnabled('FORCE_SCAN'));
+const isForceScanEnabled = computed(() => productStore.isProductStoreSettingEnabled('RECEIVE_FORCE_SCAN'));
 const barcodeIdentifier = computed(() => productStore.getBarcodeIdentifierPref);
 const productIdentificationPref = computed(() => productStore.getProductIdentificationPref);
 const currentFacility = computed(() => productStore.getCurrentFacility);

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -123,7 +123,7 @@ const observer = ref(null as IntersectionObserver | null);
 const current = computed(() => returnStore.getCurrent);
 const getProduct = computed(() => product.getProduct);
 const isReturnReceivable = computed(() => returnStore.isReturnReceivable);
-const isForceScanEnabled = computed(() => productStore.isProductStoreSettingEnabled('FORCE_SCAN'));
+const isForceScanEnabled = computed(() => productStore.isProductStoreSettingEnabled('RECEIVE_FORCE_SCAN'));
 const barcodeIdentifier = computed(() => productStore.getBarcodeIdentifierPref);
 const productIdentificationPref = computed(() => productStore.getProductIdentificationPref);
 

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -403,8 +403,8 @@ const scanErrorText = ref("");
 
 const order = computed(() => transferOrderStore.getCurrent);
 const getProduct = computed(() => product.getProduct);
-const isForceScanEnabled = computed(() => productStore.isProductStoreSettingEnabled('FORCE_SCAN'));
-const isReceivingByFulfillment = computed(() => productStore.isProductStoreSettingEnabled('RECEIVE_BY_FULFILLMENT'));
+const isForceScanEnabled = computed(() => productStore.isProductStoreSettingEnabled('RECEIVE_FORCE_SCAN'));
+const isReceivingByFulfillment = computed(() => productStore.isProductStoreSettingEnabled('RECEIVE_BY_FULFILL'));
 const barcodeIdentifier = computed(() => productStore.getBarcodeIdentifierPref);
 const productIdentificationPref = computed(() => productStore.getProductIdentificationPref);
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

closes #713 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Enums are wrong when mapping it with fetched value from backend
- RECEIVE_BY_FULFILLMENT -> RECEIVE_BY_FULFILL
- FORCE_SCAN -> RECEIVE_FORCE_SCAN

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/hotwax/receiving#contribution-guideline)