### PR TITLE
Improved: Centralized app permissions into a single authorization actions file.

### DIFF
--- a/src/authorization/actions.ts
+++ b/src/authorization/actions.ts
@@ -1,0 +1,24 @@
+/**
+ * App actions mapped to the server permissions they require.
+ *
+ * Views, components and routes should always refer to an action from this file instead of
+ * hardcoding a server permission, so that a permission change is a one line change here.
+ *
+ * The value is the permission expression evaluated by `hasPermission` of the user store.
+ * It supports the `OR` and `AND` operators, and an empty value means the action is allowed
+ * for every logged in user.
+ */
+export default {
+  APP_PURCHASEORDERS_VIEW: "",
+  APP_PURCHASEORDER_DETAIL_VIEW: "",
+  APP_RETURNS_VIEW: "",
+  APP_RETURN_DETAIL_VIEW: "",
+  APP_TRANSFERORDERS_VIEW: "",
+  APP_TRANSFERORDER_DETAIL_VIEW: "",
+  APP_SHIPMENT_UPDATE: "RECEIVING_ADMIN",
+  APP_RECVG_ADMIN: "COMMON_ADMIN",
+  APP_PRODUCT_IDENTIFIER_UPDATE: "COMMON_ADMIN",
+  APP_BARCODE_IDENTIFIER_UPDATE: "COMMON_ADMIN",
+  APP_UPDT_FULFILL_FORCE_SCAN_CONFIG: "COMMON_ADMIN",
+  APP_UPDT_RECEIVE_FLOW_CONFIG: "COMMON_ADMIN"
+} as const satisfies Record<string, string>

--- a/src/components/ClosePurchaseOrderModal.vue
+++ b/src/components/ClosePurchaseOrderModal.vue
@@ -35,7 +35,7 @@
   </ion-content>
 
   <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-    <ion-fab-button data-testid="purchase-order-close-items-save-btn" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || !isEligibleToClosePOItems()" @click="confirmSave">
+    <ion-fab-button data-testid="purchase-order-close-items-save-btn" :disabled="!userStore.hasPermission(Actions.APP_SHIPMENT_UPDATE) || !isEligibleToClosePOItems()" @click="confirmSave">
       <ion-icon :icon="saveOutline" />
     </ion-fab-button>
   </ion-fab>
@@ -51,6 +51,7 @@ import { useProductStore as useProduct } from '@/store/product';
 import { DxpShopifyImg, translate, commonUtil, emitter } from '@common';
 import { useProductStore } from '@/store/productStore';
 import router from '@/router';
+import Actions from "@/authorization/actions";
 
 const props = defineProps(['isEligibileForCreatingShipment']);
 

--- a/src/components/DxpProductIdentifier.vue
+++ b/src/components/DxpProductIdentifier.vue
@@ -11,12 +11,12 @@
       {{ 'Choosing a product identifier allows you to view products with your preferred identifiers.' }}
     </ion-card-content>
 
-    <ion-item :disabled="!userStore.hasPermission('COMMON_ADMIN')">
+    <ion-item :disabled="!userStore.hasPermission(Actions.APP_PRODUCT_IDENTIFIER_UPDATE)">
       <ion-select :label="translate('Primary')" interface="popover" :placeholder="'primary identifier'" :value="productIdentificationPref.primaryId" @ionChange="setProductIdentificationPref($event.detail.value, 'primaryId')">
         <ion-select-option v-for="identification in productIdentificationOptions" :key="identification.goodIdentificationTypeId" :value="identification.goodIdentificationTypeId" >{{ identification.description ? identification.description : identification.goodIdentificationTypeId }}</ion-select-option>
       </ion-select>
     </ion-item>
-    <ion-item lines="none" :disabled="!userStore.hasPermission('COMMON_ADMIN')">
+    <ion-item lines="none" :disabled="!userStore.hasPermission(Actions.APP_PRODUCT_IDENTIFIER_UPDATE)">
       <ion-select :label="translate('Secondary')" interface="popover" :placeholder="'secondary identifier'" :value="productIdentificationPref.secondaryId" @ionChange="setProductIdentificationPref($event.detail.value, 'secondaryId')">
         <ion-select-option v-for="identification in productIdentificationOptions" :key="identification.goodIdentificationTypeId" :value="identification.goodIdentificationTypeId" >{{ identification.description ? identification.description : identification.goodIdentificationTypeId }}</ion-select-option>
         <ion-select-option value="">{{ "None" }}</ion-select-option>
@@ -49,6 +49,7 @@ import { useUserStore } from '@/store/user'
 import { computed, onMounted } from 'vue';
 import { commonUtil, DxpShopifyImg, translate } from "@common";
 import { shuffleOutline } from "ionicons/icons";
+import Actions from "@/authorization/actions";
 
 const productStore = useProductStore();
 const userStore = useUserStore()

--- a/src/components/ReceiveTransferOrder.vue
+++ b/src/components/ReceiveTransferOrder.vue
@@ -45,7 +45,7 @@
     <ion-toolbar class="ion-padding-start">
       <ion-label slot="start">{{ translate("Select all items to proceed") }}</ion-label>
       <ion-buttons slot="end">
-        <ion-button data-testid="transfer-order-receive-modal-save-btn" fill="solid" color="primary" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || !isEligibleToCloseTOItems()" @click="saveProgress">{{ saveButtonLabel }}</ion-button>
+        <ion-button data-testid="transfer-order-receive-modal-save-btn" fill="solid" color="primary" :disabled="!userStore.hasPermission(Actions.APP_SHIPMENT_UPDATE) || !isEligibleToCloseTOItems()" @click="saveProgress">{{ saveButtonLabel }}</ion-button>
       </ion-buttons>
     </ion-toolbar>
   </ion-footer>
@@ -60,6 +60,7 @@ import { useProductStore as useProduct } from '@/store/product'
 import { useUtilStore } from '@/store/util'
 import { useProductStore } from '@/store/productStore';
 import { commonUtil, DxpShopifyImg, translate } from '@common';
+import Actions from "@/authorization/actions";
 
 const props = defineProps(["closeTO", "items", "receivedUnitsFraction"])
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -8,6 +8,7 @@ import ReturnDetails from '@/views/ReturnDetails.vue'
 import TransferOrders from '@/views/TransferOrders.vue';
 import TransferOrderDetail from '@/views/TransferOrderDetail.vue';
 import { useUserStore } from '@/store/user';
+import Actions from '@/authorization/actions';
 import { translate, commonUtil, useAuth, ShopifyLogin, ShopifyAppInstall, Login } from '@common'
 
 import { businessOutline, calendar, gitPullRequestOutline, settingsOutline } from "ionicons/icons";
@@ -68,7 +69,7 @@ const routes: Array<RouteRecordRaw> = [
     component: PurchaseOrders,
     beforeEnter: authGuard,
     meta: {
-      permissionId: "",
+      permissionId: Actions.APP_PURCHASEORDERS_VIEW,
       title: "Purchase Orders",
       icon: calendar,
       menuIndex: 4,
@@ -81,7 +82,7 @@ const routes: Array<RouteRecordRaw> = [
     component: PurchaseOrderDetail,
     beforeEnter: authGuard,
     meta: {
-      permissionId: ""
+      permissionId: Actions.APP_PURCHASEORDER_DETAIL_VIEW
     }
   },
   {
@@ -95,7 +96,7 @@ const routes: Array<RouteRecordRaw> = [
     component: Returns,
     beforeEnter: authGuard,
     meta: {
-      permissionId: "",
+      permissionId: Actions.APP_RETURNS_VIEW,
       title: "Returns",
       icon: gitPullRequestOutline,
       menuIndex: 3,
@@ -108,7 +109,7 @@ const routes: Array<RouteRecordRaw> = [
     component: ReturnDetails,
     beforeEnter: authGuard,
     meta: {
-      permissionId: ""
+      permissionId: Actions.APP_RETURN_DETAIL_VIEW
     }
   },
   {
@@ -117,7 +118,7 @@ const routes: Array<RouteRecordRaw> = [
     component: TransferOrders,
     beforeEnter: authGuard,
     meta: {
-      permissionId: "",
+      permissionId: Actions.APP_TRANSFERORDERS_VIEW,
       title: "Transfer Orders",
       icon: businessOutline,
       menuIndex: 2,
@@ -130,7 +131,7 @@ const routes: Array<RouteRecordRaw> = [
     component: TransferOrderDetail,
     beforeEnter: authGuard,
     meta: {
-      permissionId: ""
+      permissionId: Actions.APP_TRANSFERORDER_DETAIL_VIEW
     }
   },
   // {

--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { api, commonUtil, logger, translate, useEmbeddedAppStore, useSolrSearch } from '@common'
 import { useUserStore } from '@/store/user'
+import Actions from "@/authorization/actions"
 const defaultProductStoreSettings = JSON.parse(import.meta.env.VITE_DEFAULT_PRODUCT_STORE_SETTINGS as string || '{}')
 
 export const useProductStore = defineStore('productStore', {
@@ -65,7 +66,7 @@ export const useProductStore = defineStore('productStore', {
       let resp = {} as any
 
       const partyId = userStore.getUserProfile?.partyId;
-      const isAdminUser = userStore.hasPermission("COMMON_ADMIN");
+      const isAdminUser = userStore.hasPermission(Actions.APP_RECVG_ADMIN);
 
       try {
         this.currentFacility = {

--- a/src/views/PurchaseOrderDetail.vue
+++ b/src/views/PurchaseOrderDetail.vue
@@ -8,7 +8,7 @@
           <ion-button data-testid="purchase-order-detail-page-history-btn" @click="receivingHistory()">
             <ion-icon slot="icon-only" :icon="timeOutline"/>
           </ion-button>
-          <ion-button data-testid="purchase-order-detail-page-add-product-btn" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || isPOReceived()" @click="addProduct">
+          <ion-button data-testid="purchase-order-detail-page-add-product-btn" :disabled="!userStore.hasPermission(Actions.APP_SHIPMENT_UPDATE) || isPOReceived()" @click="addProduct">
             <ion-icon slot="icon-only" :icon="addOutline"/>
           </ion-button>
         </ion-buttons>
@@ -149,8 +149,8 @@
     <ion-footer data-testid="purchase-order-detail-page-footer" v-if="!isPOReceived()">
       <ion-toolbar>
         <ion-buttons slot="end">
-          <ion-button data-testid="purchase-order-detail-page-receive-close-btn" fill="outline" size="small" color="primary" :disabled="!userStore.hasPermission('RECEIVING_ADMIN')" class="ion-margin-end" @click="closePO">{{ translate("Receive And Close") }}</ion-button>
-          <ion-button data-testid="purchase-order-detail-page-receive-btn" fill="solid" size="small" color="primary" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || !isEligibileForCreatingShipment()" @click="savePODetails">{{ translate("Receive") }}</ion-button>
+          <ion-button data-testid="purchase-order-detail-page-receive-close-btn" fill="outline" size="small" color="primary" :disabled="!userStore.hasPermission(Actions.APP_SHIPMENT_UPDATE)" class="ion-margin-end" @click="closePO">{{ translate("Receive And Close") }}</ion-button>
+          <ion-button data-testid="purchase-order-detail-page-receive-btn" fill="solid" size="small" color="primary" :disabled="!userStore.hasPermission(Actions.APP_SHIPMENT_UPDATE) || !isEligibileForCreatingShipment()" @click="savePODetails">{{ translate("Receive") }}</ion-button>
         </ion-buttons>
       </ion-toolbar>
     </ion-footer>
@@ -174,6 +174,7 @@ import { useProductStore as useProduct } from '@/store/product';
 import { useUserStore } from '@/store/user';
 import { useProductStore } from '@/store/productStore';
 import router from '@/router';
+import Actions from "@/authorization/actions";
 
 const route = router.currentRoute.value
 const orderStore = useOrderStore();

--- a/src/views/ReturnDetails.vue
+++ b/src/views/ReturnDetails.vue
@@ -78,7 +78,7 @@
       </main>
 
       <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-        <ion-fab-button data-testid="return-detail-page-complete-btn" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || !isEligibleForReceivingReturns()" v-if="isReturnReceivable(current.statusId)" @click="completeShipment">
+        <ion-fab-button data-testid="return-detail-page-complete-btn" :disabled="!userStore.hasPermission(Actions.APP_SHIPMENT_UPDATE) || !isEligibleForReceivingReturns()" v-if="isReturnReceivable(current.statusId)" @click="completeShipment">
           <ion-icon :icon="checkmarkDone" />
         </ion-fab-button>
       </ion-fab>
@@ -99,6 +99,7 @@ import Scanner from "@/components/Scanner.vue";
 import ImageModal from '@/components/ImageModal.vue';
 import { useUserStore } from '@/store/user'
 import router from '@/router';
+import Actions from "@/authorization/actions";
 
 const props = defineProps(['shipment']);
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -49,10 +49,10 @@
             </ion-card-title>
           </ion-card-header>
           <ion-card-content v-html="barcodeContentMessage"></ion-card-content>
-          <ion-item lines="none" :disabled="!userStore.hasPermission('COMMON_ADMIN')">
+          <ion-item lines="none" :disabled="!userStore.hasPermission(Actions.APP_UPDT_FULFILL_FORCE_SCAN_CONFIG)">
             <ion-toggle label-placement="start" :checked="isProductStoreSettingEnabled('RECEIVE_FORCE_SCAN')" @click.prevent="updateForceScanStatus($event)">{{ translate("Require scan") }}</ion-toggle>
           </ion-item>
-          <ion-item lines="none" :disabled="!userStore.hasPermission('COMMON_ADMIN')">
+          <ion-item lines="none" :disabled="!userStore.hasPermission(Actions.APP_BARCODE_IDENTIFIER_UPDATE)">
             <ion-select :label="translate('Barcode Identifier')" interface="popover" :placeholder="translate('Select')" :value="barcodeIdentificationPref" @ionChange="setBarcodeIdentificationPref($event.detail.value)">
               <ion-select-option v-for="identification in barcodeIdentificationOptions" :key="identification.goodIdentificationTypeId" :value="identification.goodIdentificationTypeId">{{ identification.description ? translate(identification.description) : identification.goodIdentificationTypeId }}</ion-select-option>
             </ion-select>
@@ -84,7 +84,7 @@
           <ion-card-content>
             {{ translate("Inventory of the transferred items will be received by fulfillment app.") }}
           </ion-card-content>
-          <ion-item lines="none" :disabled="!userStore.hasPermission('COMMON_ADMIN')">
+          <ion-item lines="none" :disabled="!userStore.hasPermission(Actions.APP_UPDT_RECEIVE_FLOW_CONFIG)">
             <ion-toggle label-placement="start" :checked="isProductStoreSettingEnabled('RECEIVE_BY_FULFILL')" @click.prevent="confirmReceiveByFulfillment($event)">{{ translate("Receive by fulfillment") }}</ion-toggle>
           </ion-item>
         </ion-card>
@@ -107,6 +107,7 @@ import DxpAppVersionInfo from "@/components/DxpAppVersionInfo.vue";
 import DxpProductIdentifier from "@/components/DxpProductIdentifier.vue";
 import DxpTimeZoneSwitcher from "@/components/DxpTimeZoneSwitcher.vue";
 import { firebaseUtil } from "@/utils/firebaseUtil"
+import Actions from "@/authorization/actions"
 
 const userStore = useUserStore();
 const productStore = useProductStore();

--- a/src/views/TransferOrderDetail.vue
+++ b/src/views/TransferOrderDetail.vue
@@ -8,7 +8,7 @@
           <ion-button data-testid="transfer-order-detail-page-history-btn" @click="receivingHistory()">
             <ion-icon slot="icon-only" :icon="timeOutline"/>
           </ion-button>
-          <ion-button data-testid="transfer-order-detail-page-add-product-btn" :disabled="!userStore.hasPermission('RECEIVING_ADMIN') || isTOReceived()" @click="addProduct">
+          <ion-button data-testid="transfer-order-detail-page-add-product-btn" :disabled="!userStore.hasPermission(Actions.APP_SHIPMENT_UPDATE) || isTOReceived()" @click="addProduct">
             <ion-icon slot="icon-only" :icon="addOutline"/>
           </ion-button>
         </ion-buttons>
@@ -374,6 +374,7 @@ import ReceiveTransferOrder from '@/components/ReceiveTransferOrder.vue';
 import router from '@/router';
 import { useReceiveFlowState } from '@/composables/useReceiveFlowState';
 import { runTransferOrderDetailReceiveWorkflow } from '@/views/transferOrderDetailReceiveWorkflow';
+import Actions from "@/authorization/actions";
 
 const transferOrderStore = useTransferOrderStore();
 const product = useProduct();
@@ -613,7 +614,7 @@ const receivingHistory = async (productId?: string, orderItemSeqId?: string) => 
 const receivingAlert = async () => {
   let message = "Specify quantity for at least one of the items to receive";
 
-  if (!userStore.hasPermission('RECEIVING_ADMIN')) {
+  if (!userStore.hasPermission(Actions.APP_SHIPMENT_UPDATE)) {
     message = "You do not have permission to receive items";
   }
 
@@ -654,7 +655,7 @@ const isAnyItemOverReceived = () => {
 
 const confirmSaveProgress = async () => {
   dismissToast();
-  if (!isEligibleForCreatingShipment() || !userStore.hasPermission('RECEIVING_ADMIN')) {
+  if (!isEligibleForCreatingShipment() || !userStore.hasPermission(Actions.APP_SHIPMENT_UPDATE)) {
     await receivingAlert();
     return false;
   }
@@ -698,7 +699,7 @@ const showAllOpenItems = () => {
 
 const confirmReceiveAndClose = async () => {
   dismissToast();
-  if (!isEligibleForCreatingShipment(true) || !userStore.hasPermission('RECEIVING_ADMIN')) {
+  if (!isEligibleForCreatingShipment(true) || !userStore.hasPermission(Actions.APP_SHIPMENT_UPDATE)) {
     await receivingAlert();
     return false;
   }


### PR DESCRIPTION
Introduces `src/authorization/actions.ts`, a single map of app action to the server permission it requires. Views, components and routes now pass an action instead of a hardcoded permission string, so a permission change is a one line change in that file.

Action names are taken from the pre-migration `src/authorization/Rules.ts` wherever a rule matched, so they stay familiar. The value is the permission expression itself, so the user store's `hasPermission` is unchanged.

No behaviour change: every call site resolves to the exact same permission expression as before.